### PR TITLE
Use only one hop directly in to okta enabled roles

### DIFF
--- a/lib/provider.go
+++ b/lib/provider.go
@@ -102,17 +102,6 @@ func (p *Provider) Retrieve() (credentials.Value, error) {
 		(*session.AccessKeyId)[len(*session.AccessKeyId)-4:],
 		session.Expiration.Sub(time.Now()).String())
 
-	if role, ok := p.profiles[p.profile]["role_arn"]; ok {
-		session, err = p.assumeRoleFromSession(session, role)
-		if err != nil {
-			return credentials.Value{}, err
-		}
-
-		log.Debugf("using role %s expires in %s",
-			(*session.AccessKeyId)[len(*session.AccessKeyId)-4:],
-			session.Expiration.Sub(time.Now()).String())
-	}
-
 	p.SetExpiration(*session.Expiration, window)
 	p.expires = *session.Expiration
 


### PR DESCRIPTION
I actually thought of one big selling point to this approach. It is consistent with the documentation that Okta gives people to set up Okta with multiple AWS accounts: http://saml-doc.okta.com/SAML_Docs/How-to-Configure-SAML-2.0-for-Amazon-Web-Service#scenarioB
