### PR TITLE
Allow assuming a source profile.

### DIFF
--- a/lib/provider.go
+++ b/lib/provider.go
@@ -105,7 +105,7 @@ func (p *Provider) Retrieve() (credentials.Value, error) {
 	// If sourceProfile returns the same source then we do not need to assume a
 	// second role. Not assuming a second role allows us to assume IDP enabled
 	// roles directly.
-	if p.profile != sourceProfile(p.profile, p.profiles) {
+	if p.profile != source {
 		if role, ok := p.profiles[p.profile]["role_arn"]; ok {
 			session, err = p.assumeRoleFromSession(session, role)
 			if err != nil {


### PR DESCRIPTION
If the source profile is itself, then don't do the second assume.
Instead, just jump in to the okta enabled role.