### PR TITLE
Update makefile and readme instructions for mac release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 version := $$CIRCLE_TAG
 
 release: gh-release govendor clean dist
-	govendor sync
 	github-release release \
 	--security-token $$GH_LOGIN \
 	--user segmentio \
@@ -14,24 +13,30 @@ release: gh-release govendor clean dist
 	--user segmentio \
 	--repo aws-okta \
 	--tag $(version) \
-	--name aws-okta-$(version)-darwin-amd64 \
-	--file dist/aws-okta-$(version)-darwin-amd64
+	--name aws-okta-$(version)-linux-amd64 \
+	--file dist/aws-okta-$(version)-linux-amd64
 
+release-mac: gh-release govendor clean dist-mac
 	github-release upload \
 	--security-token $$GH_LOGIN \
 	--user segmentio \
 	--repo aws-okta \
 	--tag $(version) \
-	--name aws-okta-$(version)-linux-amd64 \
-	--file dist/aws-okta-$(version)-linux-amd64
+	--name aws-okta-$(version)-darwin-amd64 \
+	--file dist/aws-okta-$(version)-darwin-amd64
 
 clean:
 	rm -rf ./dist
 
 dist:
 	mkdir dist
-	GOOS=darwin GOARCH=amd64 go build -o dist/aws-okta-$(version)-darwin-amd64
+	govendor sync
 	GOOS=linux GOARCH=amd64 go build -o dist/aws-okta-$(version)-linux-amd64
+
+dist-mac:
+	mkdir dist
+	govendor sync
+	GOOS=darwin GOARCH=amd64 go build -o dist/aws-okta-$(version)-darwin-amd64
 
 gh-release:
 	go get -u github.com/aktau/github-release

--- a/README.md
+++ b/README.md
@@ -69,6 +69,15 @@ Your setup may require additional roles to be configured if your admin has set u
 
 We use 99design's keyring package that they use in `aws-vault`.  Because of this, you can choose between different pluggable secret storage backends just like in `aws-vault`.  You can either set your backend from the command line as a flag, or set the `AWS_OKTA_BACKEND` environment variable.
 
+## Releasing
+
+Pushing a new tag will cause Circle to automatically create and push a linux release.  After this is done, you shoule run (from a mac):
+
+```bash
+$ export CIRCLE_TAG=`git describe --tags`
+$ make release-mac
+```
+
 ## Internals
 
 ### Authentication process


### PR DESCRIPTION
Mac releases must be done from a mac to get proper keychain support.