### PR TITLE
set AWS_PROFILE to arg

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -134,6 +134,7 @@ func execRun(cmd *cobra.Command, args []string) error {
 
 	env.Set("AWS_ACCESS_KEY_ID", creds.AccessKeyID)
 	env.Set("AWS_SECRET_ACCESS_KEY", creds.SecretAccessKey)
+	env.Set("AWS_PROFILE", profile)
 
 	if creds.SessionToken != "" {
 		env.Set("AWS_SESSION_TOKEN", creds.SessionToken)


### PR DESCRIPTION
I'm building a utility invoked by `aws-okta`. It would be useful for the utility to know what profile its running under.

Current behavior:

```
$ aws-okta exec prod -- env | grep prod
```

New behavior:

```
$ aws-okta exec prod -- env | grep prod
AWS_PROFILE=prod
```
