### PR TITLE
Fix keyring

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -9,7 +9,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/99designs/aws-vault/keyring"
+	"github.com/99designs/keyring"
 	"github.com/segmentio/aws-okta/lib"
 	"github.com/spf13/cobra"
 )
@@ -105,7 +105,17 @@ func execRun(cmd *cobra.Command, args []string) error {
 		AssumeRoleDuration: assumeRoleTTL,
 	}
 
-	kr, err := keyring.Open("aws-okta", backend)
+	var allowedBackends []keyring.BackendType
+	if backend != "" {
+		allowedBackends = append(allowedBackends, keyring.BackendType(backend))
+	}
+
+	kr, err := keyring.Open(keyring.Config{
+		AllowedBackends: allowedBackends,
+		// this keychain name is for backwards compatibility
+		ServiceName:  "awsvault",
+		KeychainName: "awsvault",
+	})
 	if err != nil {
 		return err
 	}

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/99designs/aws-vault/keyring"
+	"github.com/99designs/keyring"
 	"github.com/segmentio/aws-okta/lib"
 	"github.com/skratchdot/open-golang/open"
 	"github.com/spf13/cobra"
@@ -54,10 +54,16 @@ func loginRun(cmd *cobra.Command, args []string) error {
 		AssumeRoleDuration: assumeRoleTTL,
 	}
 
-	kr, err := keyring.Open("aws-okta", backend)
-	if err != nil {
-		return err
+	var allowedBackends []keyring.BackendType
+	if backend != "" {
+		allowedBackends = append(allowedBackends, keyring.BackendType(backend))
 	}
+	kr, err := keyring.Open(keyring.Config{
+		AllowedBackends: allowedBackends,
+		// this keychain name is for backwards compatibility
+		ServiceName:  "awsvault",
+		KeychainName: "awsvault",
+	})
 
 	p, err := lib.NewProvider(kr, profile, opts)
 	if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/99designs/aws-vault/keyring"
+	"github.com/99designs/keyring"
 	log "github.com/Sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -61,6 +61,10 @@ func prerun(cmd *cobra.Command, args []string) {
 }
 
 func init() {
-	RootCmd.PersistentFlags().StringVarP(&backend, "backend", "b", keyring.DefaultBackend, fmt.Sprintf("Secret backend to use %s", keyring.SupportedBackends()))
+	backendsAvailable := []string{}
+	for _, backendType := range keyring.AvailableBackends() {
+		backendsAvailable = append(backendsAvailable, string(backendType))
+	}
+	RootCmd.PersistentFlags().StringVarP(&backend, "backend", "b", "", fmt.Sprintf("Secret backend to use %s", backendsAvailable))
 	RootCmd.PersistentFlags().BoolVarP(&debug, "debug", "d", false, "Enable debug logging")
 }

--- a/lib/config.go
+++ b/lib/config.go
@@ -8,7 +8,6 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/mitchellh/go-homedir"
 	"github.com/vaughan0/go-ini"
 )
@@ -65,23 +64,4 @@ func sourceProfile(p string, from profiles) string {
 		}
 	}
 	return p
-}
-
-func formatCredentialError(p string, from profiles, err error) string {
-	source := sourceProfile(p, from)
-	sourceDescr := p
-
-	// add custom formatting for source_profile
-	if source != p {
-		sourceDescr = fmt.Sprintf("%s (source profile for %s)", source, p)
-	}
-
-	if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "NoCredentialProviders" {
-		return fmt.Sprintf(
-			"No credentials found for profile %s.\n"+
-				"Use 'aws-vault add %s' to set up credentials or 'aws-vault list' to see what credentials exist",
-			sourceDescr, source)
-	}
-
-	return fmt.Sprintf("Failed to get credentials for %s: %v", err, sourceDescr)
 }

--- a/lib/okta.go
+++ b/lib/okta.go
@@ -13,7 +13,7 @@ import (
 
 	"golang.org/x/net/publicsuffix"
 
-	"github.com/99designs/aws-vault/keyring"
+	"github.com/99designs/keyring"
 	log "github.com/Sirupsen/logrus"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"

--- a/lib/provider.go
+++ b/lib/provider.go
@@ -7,7 +7,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 
-	"github.com/99designs/aws-vault/keyring"
+	"github.com/99designs/keyring"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -40,6 +40,7 @@ func (o ProviderOptions) Validate() error {
 	if o.AssumeRoleDuration < MinAssumeRoleDuration {
 		return errors.New("Minimum duration for assumed roles is " + MinAssumeRoleDuration.String())
 	} else if o.AssumeRoleDuration > MaxAssumeRoleDuration {
+		log.Println(o.AssumeRoleDuration)
 		return errors.New("Maximum duration for assumed roles is " + MaxAssumeRoleDuration.String())
 	}
 

--- a/lib/sessions.go
+++ b/lib/sessions.go
@@ -11,7 +11,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 
-	"github.com/99designs/aws-vault/keyring"
+	"github.com/99designs/keyring"
 	"github.com/aws/aws-sdk-go/service/sts"
 )
 
@@ -65,10 +65,10 @@ func (s *KeyringSessions) Store(profile string, session sts.Credentials, duratio
 
 	log.Debugf("Writing session for %s to keyring", profile)
 	s.Keyring.Set(keyring.Item{
-		Key:       s.key(profile, duration),
-		Label:     "aws-vault session for " + profile,
-		Data:      bytes,
-		TrustSelf: true,
+		Key:   s.key(profile, duration),
+		Label: "aws-vault session for " + profile,
+		Data:  bytes,
+		KeychainNotTrustApplication: false,
 	})
 
 	return nil

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,10 +3,10 @@
 	"ignore": "test",
 	"package": [
 		{
-			"checksumSHA1": "XtbjnQIn6uhrNyEn/sSp2PXVYc8=",
-			"path": "github.com/99designs/aws-vault/keyring",
-			"revision": "04f4cf622c594b72015f0c851813f426a74799bd",
-			"revisionTime": "2017-06-16T04:15:52Z"
+			"checksumSHA1": "D8hEjr7exRaY14eEFEXCSV6YXao=",
+			"path": "github.com/99designs/keyring",
+			"revision": "5fbd4674c81065bd80b5adfee8a127c5c47e48ce",
+			"revisionTime": "2017-12-29T03:53:02Z"
 		},
 		{
 			"checksumSHA1": "DYv6Q1+VfnUVxMwvk5IshAClLvw=",
@@ -16,10 +16,9 @@
 		},
 		{
 			"checksumSHA1": "bD0oh9rHp+3ElrjWtaou004QTt8=",
-			"origin": "github.com/99designs/aws-vault/vendor/github.com/aulanov/go.dbus",
 			"path": "github.com/aulanov/go.dbus",
-			"revision": "04f4cf622c594b72015f0c851813f426a74799bd",
-			"revisionTime": "2017-06-16T04:15:52Z"
+			"revision": "25c3068a42a0b50b877953fb249dbcffc6bd1bca",
+			"revisionTime": "2015-07-29T23:15:27Z"
 		},
 		{
 			"checksumSHA1": "W/q89+AUzZNVNySmkHKFERn7OxY=",
@@ -154,60 +153,52 @@
 			"revisionTime": "2017-03-23T00:38:48Z"
 		},
 		{
-			"checksumSHA1": "rSFw3D9mMLfFx4GuETt5aWGWi64=",
-			"origin": "github.com/99designs/aws-vault/vendor/github.com/dvsekhvalnov/jose2go",
+			"checksumSHA1": "amrfOy96U1cKMVjqjMAWLAb7Mdo=",
 			"path": "github.com/dvsekhvalnov/jose2go",
-			"revision": "04f4cf622c594b72015f0c851813f426a74799bd",
-			"revisionTime": "2017-06-16T04:15:52Z"
+			"revision": "9f050a91b1f2663a30613ed12d728426599e1b2d",
+			"revisionTime": "2017-06-29T14:38:15Z"
 		},
 		{
 			"checksumSHA1": "X38qrRzL+rPyO4xZhm16ftyLkXs=",
-			"origin": "github.com/99designs/aws-vault/vendor/github.com/dvsekhvalnov/jose2go/aes",
 			"path": "github.com/dvsekhvalnov/jose2go/aes",
-			"revision": "04f4cf622c594b72015f0c851813f426a74799bd",
-			"revisionTime": "2017-06-16T04:15:52Z"
+			"revision": "9f050a91b1f2663a30613ed12d728426599e1b2d",
+			"revisionTime": "2017-06-29T14:38:15Z"
 		},
 		{
 			"checksumSHA1": "RbRzJ9jDZJnCUKbJJy7e2OSTUro=",
-			"origin": "github.com/99designs/aws-vault/vendor/github.com/dvsekhvalnov/jose2go/arrays",
 			"path": "github.com/dvsekhvalnov/jose2go/arrays",
-			"revision": "04f4cf622c594b72015f0c851813f426a74799bd",
-			"revisionTime": "2017-06-16T04:15:52Z"
+			"revision": "9f050a91b1f2663a30613ed12d728426599e1b2d",
+			"revisionTime": "2017-06-29T14:38:15Z"
 		},
 		{
 			"checksumSHA1": "uQqU76qm0Q57HnnCEp56r43jGaU=",
-			"origin": "github.com/99designs/aws-vault/vendor/github.com/dvsekhvalnov/jose2go/base64url",
 			"path": "github.com/dvsekhvalnov/jose2go/base64url",
-			"revision": "04f4cf622c594b72015f0c851813f426a74799bd",
-			"revisionTime": "2017-06-16T04:15:52Z"
+			"revision": "9f050a91b1f2663a30613ed12d728426599e1b2d",
+			"revisionTime": "2017-06-29T14:38:15Z"
 		},
 		{
 			"checksumSHA1": "h/QQYYL/tuXhe8ELZvyk1wKrZz4=",
-			"origin": "github.com/99designs/aws-vault/vendor/github.com/dvsekhvalnov/jose2go/compact",
 			"path": "github.com/dvsekhvalnov/jose2go/compact",
-			"revision": "04f4cf622c594b72015f0c851813f426a74799bd",
-			"revisionTime": "2017-06-16T04:15:52Z"
+			"revision": "9f050a91b1f2663a30613ed12d728426599e1b2d",
+			"revisionTime": "2017-06-29T14:38:15Z"
 		},
 		{
 			"checksumSHA1": "gjXFjcEV/LZG4U/lgm/CVYvvWOg=",
-			"origin": "github.com/99designs/aws-vault/vendor/github.com/dvsekhvalnov/jose2go/kdf",
 			"path": "github.com/dvsekhvalnov/jose2go/kdf",
-			"revision": "04f4cf622c594b72015f0c851813f426a74799bd",
-			"revisionTime": "2017-06-16T04:15:52Z"
+			"revision": "9f050a91b1f2663a30613ed12d728426599e1b2d",
+			"revisionTime": "2017-06-29T14:38:15Z"
 		},
 		{
 			"checksumSHA1": "o1OtVBn2DVAG07K6teBpkUNjqkM=",
-			"origin": "github.com/99designs/aws-vault/vendor/github.com/dvsekhvalnov/jose2go/keys/ecc",
 			"path": "github.com/dvsekhvalnov/jose2go/keys/ecc",
-			"revision": "04f4cf622c594b72015f0c851813f426a74799bd",
-			"revisionTime": "2017-06-16T04:15:52Z"
+			"revision": "9f050a91b1f2663a30613ed12d728426599e1b2d",
+			"revisionTime": "2017-06-29T14:38:15Z"
 		},
 		{
 			"checksumSHA1": "gAEKTUiQk9JoMonf1G508SXpLw4=",
-			"origin": "github.com/99designs/aws-vault/vendor/github.com/dvsekhvalnov/jose2go/padding",
 			"path": "github.com/dvsekhvalnov/jose2go/padding",
-			"revision": "04f4cf622c594b72015f0c851813f426a74799bd",
-			"revisionTime": "2017-06-16T04:15:52Z"
+			"revision": "9f050a91b1f2663a30613ed12d728426599e1b2d",
+			"revisionTime": "2017-06-29T14:38:15Z"
 		},
 		{
 			"checksumSHA1": "VvZKmbuBN1QAG699KduTdmSPwA4=",
@@ -217,18 +208,16 @@
 			"revisionTime": "2017-03-23T00:38:48Z"
 		},
 		{
-			"checksumSHA1": "prN+IUOs6KunsgMUPhYcUgfhTbs=",
-			"origin": "github.com/99designs/aws-vault/vendor/github.com/godbus/dbus",
+			"checksumSHA1": "PPQMuYSOEXwd4UgDqK+gIoY3cFQ=",
 			"path": "github.com/godbus/dbus",
-			"revision": "04f4cf622c594b72015f0c851813f426a74799bd",
-			"revisionTime": "2017-06-16T04:15:52Z"
+			"revision": "885f9cc04c9c1a6a61a2008e211d36c5737be3f5",
+			"revisionTime": "2018-01-24T01:07:25Z"
 		},
 		{
 			"checksumSHA1": "IZJQgK68T/tXTTezcUs5yLzmkTQ=",
-			"origin": "github.com/99designs/aws-vault/vendor/github.com/gsterjov/go-libsecret",
 			"path": "github.com/gsterjov/go-libsecret",
-			"revision": "04f4cf622c594b72015f0c851813f426a74799bd",
-			"revisionTime": "2017-06-16T04:15:52Z"
+			"revision": "a6f4afe4910cad8688db3e0e9b9ac92ad22d54e1",
+			"revisionTime": "2016-10-01T09:47:33Z"
 		},
 		{
 			"checksumSHA1": "40vJyUB4ezQSn/NSadsKEOrudMc=",
@@ -242,6 +231,12 @@
 			"path": "github.com/jmespath/go-jmespath",
 			"revision": "3bc643c63c6f8716320182b6842581d6c80572fa",
 			"revisionTime": "2017-03-23T00:38:48Z"
+		},
+		{
+			"checksumSHA1": "qSLh0MUE8SskTMjP+bfJ3Ap5M7c=",
+			"origin": "github.com/dfuentes/go-keychain",
+			"path": "github.com/keybase/go-keychain",
+			"revision": "569a68cce0f5e9255938db33daab4ae53ace992a"
 		},
 		{
 			"checksumSHA1": "V/quM7+em2ByJbWBLOsEwnY3j/Q=",
@@ -286,19 +281,19 @@
 			"revisionTime": "2016-03-29T01:55:07Z"
 		},
 		{
-			"checksumSHA1": "00eQaGynDYrv3tL+C7l9xH0IDZg=",
+			"checksumSHA1": "z79z5msRzgU48FCZxSuxfU8b4rs=",
 			"path": "golang.org/x/net/html/atom",
 			"revision": "3e8a7b0329d536af18e227bb21b6da4d1dbbe180",
 			"revisionTime": "2016-03-29T01:55:07Z"
 		},
 		{
-			"checksumSHA1": "uR2JExVr6/6ZrBtvm7XguieokNI=",
+			"checksumSHA1": "9GGbaBrJHJOSnAdpo+Xkhwado3M=",
 			"path": "golang.org/x/net/publicsuffix",
 			"revision": "3e8a7b0329d536af18e227bb21b6da4d1dbbe180",
 			"revisionTime": "2016-03-29T01:55:07Z"
 		},
 		{
-			"checksumSHA1": "s+jPD0dANCQ66tN5Rmmxc2WT5W0=",
+			"checksumSHA1": "FabjX8CIwjHaz5+VYUjw8wXONeY=",
 			"path": "golang.org/x/sys/unix",
 			"revision": "b4e289961544fc90f340c908c3460ceae6a2202a",
 			"revisionTime": "2015-06-12T01:39:23Z"


### PR DESCRIPTION
Move from importing 99designs/aws-vault/keyring to using 99designs/keyring directly.  Most of the changes are adapting to the new keyring API.

Also updates vendor to use a fork of keybase/go-keychain that allows for building on all versions of go.  We can go back to the original if https://github.com/keybase/go-keychain/pull/22 gets merged