### PR TITLE
fix session label

### DIFF
--- a/lib/sessions.go
+++ b/lib/sessions.go
@@ -66,7 +66,7 @@ func (s *KeyringSessions) Store(profile string, session sts.Credentials, duratio
 	log.Debugf("Writing session for %s to keyring", profile)
 	s.Keyring.Set(keyring.Item{
 		Key:   s.key(profile, duration),
-		Label: "aws-vault session for " + profile,
+		Label: "aws session for " + profile,
 		Data:  bytes,
 		KeychainNotTrustApplication: false,
 	})


### PR DESCRIPTION
There's also a few other references to vault.  Not sure which others are obsolete.

```
09:47:13 $ ag 'vault'
cmd/add.go
35:             LibSecretCollectionName: "awsvault",

cmd/exec.go
118:            LibSecretCollectionName: "awsvault",

cmd/login.go
66:             LibSecretCollectionName: "awsvault",
133:            "https://signin.aws.amazon.com/federation?Action=login&Issuer=aws-vault&Destination=%s&SigninToken=%s",

README.md
29:Exec will assume the role specified by the given aws config profile and execute a command with the proper environment variables set.  This command is a drop-in replacement for `aws-vault exec` and accepts all of the same command line flags:
70:We use 99design's keyring package that they use in `aws-vault`.  Because of this, you can choose between different pluggable secret storage backends just like in `aws-vault`.  You can either set your backend from the command line as a flag, or set the `AWS_OKTA_BACKEND` environment variable.

lib/sessions.go
69:             Label: "aws-vault session for " + profile,
```