### PR TITLE
Less auth prompts

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -31,7 +31,7 @@ func add(cmd *cobra.Command, args []string) error {
 		AllowedBackends:          allowedBackends,
 		KeychainTrustApplication: true,
 		// this keychain name is for backwards compatibility
-		ServiceName:             "aws-okta",
+		ServiceName:             "aws-okta-login",
 		LibSecretCollectionName: "awsvault",
 	})
 

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -28,10 +28,10 @@ func add(cmd *cobra.Command, args []string) error {
 		allowedBackends = append(allowedBackends, keyring.BackendType(backend))
 	}
 	kr, err := keyring.Open(keyring.Config{
-		AllowedBackends: allowedBackends,
+		AllowedBackends:          allowedBackends,
+		KeychainTrustApplication: true,
 		// this keychain name is for backwards compatibility
 		ServiceName:             "aws-okta",
-		KeychainName:            "aws-okta",
 		LibSecretCollectionName: "awsvault",
 	})
 

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -114,7 +114,7 @@ func execRun(cmd *cobra.Command, args []string) error {
 		AllowedBackends:          allowedBackends,
 		KeychainTrustApplication: true,
 		// this keychain name is for backwards compatibility
-		ServiceName:             "aws-okta",
+		ServiceName:             "aws-okta-login",
 		LibSecretCollectionName: "awsvault",
 	})
 	if err != nil {

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -111,10 +111,10 @@ func execRun(cmd *cobra.Command, args []string) error {
 	}
 
 	kr, err := keyring.Open(keyring.Config{
-		AllowedBackends: allowedBackends,
+		AllowedBackends:          allowedBackends,
+		KeychainTrustApplication: true,
 		// this keychain name is for backwards compatibility
 		ServiceName:             "aws-okta",
-		KeychainName:            "aws-okta",
 		LibSecretCollectionName: "awsvault",
 	})
 	if err != nil {

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -62,7 +62,7 @@ func loginRun(cmd *cobra.Command, args []string) error {
 		AllowedBackends:          allowedBackends,
 		KeychainTrustApplication: true,
 		// this keychain name is for backwards compatibility
-		ServiceName:             "aws-okta",
+		ServiceName:             "aws-okta-login",
 		LibSecretCollectionName: "awsvault",
 	})
 

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -59,10 +59,10 @@ func loginRun(cmd *cobra.Command, args []string) error {
 		allowedBackends = append(allowedBackends, keyring.BackendType(backend))
 	}
 	kr, err := keyring.Open(keyring.Config{
-		AllowedBackends: allowedBackends,
+		AllowedBackends:          allowedBackends,
+		KeychainTrustApplication: true,
 		// this keychain name is for backwards compatibility
 		ServiceName:             "aws-okta",
-		KeychainName:            "aws-okta",
 		LibSecretCollectionName: "awsvault",
 	})
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,9 +3,10 @@
 	"ignore": "test",
 	"package": [
 		{
-			"checksumSHA1": "D8hEjr7exRaY14eEFEXCSV6YXao=",
+			"checksumSHA1": "fLvccQm6HM0159IUkzXC3qRtKUw=",
+			"origin": "github.com/dfuentes/keyring",
 			"path": "github.com/99designs/keyring",
-			"revision": "5fbd4674c81065bd80b5adfee8a127c5c47e48ce",
+			"revision": "d83eda70f5bc1d7df8f321e51ef6ac5f932f32f3",
 			"revisionTime": "2017-12-29T03:53:02Z"
 		},
 		{


### PR DESCRIPTION
- Use fork of keyring that allows setting ACL's correctly
- Use login keychain