### PR TITLE
Support for token MFA type

### DIFF
--- a/lib/okta.go
+++ b/lib/okta.go
@@ -184,6 +184,16 @@ func (o *OktaClient) challengeMFA() (err error) {
 		return
 	}
 
+	if o.UserAuth.Embedded.Factor.FactorType == "token:software:totp" {
+		reader := bufio.NewReader(os.Stdin)
+		fmt.Print("Enter 2 Factor Code: ")
+		mfaCode, err := reader.ReadString('\n')
+		if err != nil {
+			return
+		}
+		payload.PassCode = mfaCode
+	}
+
 	err = o.Get("POST", "api/v1/authn/factors/"+oktaFactorId+"/verify",
 		payload, &o.UserAuth, "json",
 	)
@@ -239,7 +249,10 @@ func GetFactorId(f *OktaUserAuthnFactor) (id string, err error) {
 	switch f.FactorType {
 	case "web":
 		id = f.Id
+	case "token:software:totp":
+		id = f.Id
 	default:
+		fmt.Print("what's up")
 		err = fmt.Errorf("factor %s not supported", f.FactorType)
 	}
 	return

--- a/lib/okta.go
+++ b/lib/okta.go
@@ -201,6 +201,7 @@ func (o *OktaClient) challengeMFA() (err error) {
 		return
 	}
 	log.Debugf("Okta Factor ID: %s\n", oktaFactorId)
+	log.Debugf("Okta Factor Type: %s\n", oktaFactorType)
 
 	var mfaCode string
 	if strings.Contains(oktaFactorType, "token") {
@@ -278,9 +279,8 @@ func GetFactorId(f *OktaUserAuthnFactor) (id string, err error) {
 	case "token:hardware":
 		id = f.Id
 	default:
-		err = fmt.Errorf("factor %s supported", f.FactorType)
+		err = fmt.Errorf("factor %s not supported", f.FactorType)
 	}
-	log.Debugf("Okta Factor Type: %s\n", f.FactorType)
 	return
 }
 

--- a/lib/okta.go
+++ b/lib/okta.go
@@ -192,7 +192,7 @@ func (o *OktaClient) challengeMFA() (err error) {
 			return err
 		}
 	} else {
-		if o.UserAuth.Embedded.Factors != nil {
+		if o.UserAuth.Embedded.Factors[0] != nil {
 			oktaFactorId, err = GetFactorId(&o.UserAuth.Embedded.Factors[0])
 			oktaFactorType = o.UserAuth.Embedded.Factors[0].FactorType
 		}

--- a/lib/struct.go
+++ b/lib/struct.go
@@ -8,6 +8,7 @@ type OktaUser struct {
 
 type OktaStateToken struct {
 	StateToken string `json:"stateToken"`
+	PassCode   string `json:"passCode"`
 }
 
 type OktaUserAuthn struct {


### PR DESCRIPTION
This supports okta's token MFA type, for Google Authenticator and other software based OTP solutions, as well as token:hardware for YubiKeys.

Note: this does not support U2F (https://developer.okta.com/docs/api/resources/authn#verify-u2f-factor)