### PR TITLE
allow login url to go to stdout

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -20,8 +20,12 @@ var loginCmd = &cobra.Command{
 	RunE:  loginRun,
 }
 
+// Stdout is the bool for -stdout
+var Stdout bool
+
 func init() {
 	RootCmd.AddCommand(loginCmd)
+	loginCmd.Flags().BoolVarP(&Stdout, "stdout", "", false, "Print login URL to stdout instead of opening in default browser")
 }
 
 func loginRun(cmd *cobra.Command, args []string) error {
@@ -135,8 +139,11 @@ func loginRun(cmd *cobra.Command, args []string) error {
 		url.QueryEscape(signinToken),
 	)
 
-	if err = open.Run(loginURL); err != nil {
+	if Stdout {
+		fmt.Println(loginURL)
+	} else if err = open.Run(loginURL); err != nil {
 		return err
 	}
+
 	return nil
 }


### PR DESCRIPTION
Workaround for #17 

This is just like [aws-vault](https://github.com/99designs/aws-vault/blob/master/cli/login.go#L187) and allows other browsers to be called via shell configuration like this:

```shell
cat `which awslogin`
#!/bin/bash

aws-okta login $1 --stdout | xargs -t /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --incognito --new-window
```

This is borrowed from: https://github.com/FernandoMiguel/kb/blob/master/Chrome/aws-vault.md