### PR TITLE
setting AWS_PROFILE as part of exec leads to errors in some apps:

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -145,7 +145,6 @@ func execRun(cmd *cobra.Command, args []string) error {
 
 	env.Set("AWS_ACCESS_KEY_ID", creds.AccessKeyID)
 	env.Set("AWS_SECRET_ACCESS_KEY", creds.SecretAccessKey)
-	env.Set("AWS_PROFILE", profile)
 
 	if creds.SessionToken != "" {
 		env.Set("AWS_SESSION_TOKEN", creds.SessionToken)


### PR DESCRIPTION
- Some apps (for example, packer) use the AWS_PROFILE setting to
  determine which profile to load out of ~/.aws/config shared config.
  The problem is that these profiles don't have associated
  credentials, so those applications fail.  Instead, don't set
  profile, and the applications just use the AWS_ACCESS_KEY_ID and
  AWS_SECRET_ACCESS_KEY vars.