### PR TITLE
fix password prompt error in windows

### DIFF
--- a/lib/prompt.go
+++ b/lib/prompt.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"syscall"
 
 	"golang.org/x/crypto/ssh/terminal"
 )
@@ -13,7 +14,7 @@ func Prompt(prompt string, sensitive bool) (string, error) {
 	fmt.Printf("%s: ", prompt)
 	if sensitive {
 		var input []byte
-		input, err := terminal.ReadPassword(1)
+		input, err := terminal.ReadPassword(int(syscall.Stdin))
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
Tried compiling tool for windows and encountered these issues before getting it to work.

First I need to fix keyring dependency: [PR](https://github.com/99designs/keyring/pull/19)

After I am able to compile this line failed with "The handle is not defined" in windows. Used syscal.Stdin as suggested on this [thread](https://github.com/golang/go/issues/11914):

I tested changes on Windows and Mac.