### PR TITLE
store session name in keychain to use it during assumeRoleFromSession

### DIFF
--- a/lib/provider.go
+++ b/lib/provider.go
@@ -90,13 +90,14 @@ func (p *Provider) Retrieve() (credentials.Value, error) {
 	}
 
 	source := sourceProfile(p.profile, p.profiles)
-	session, err := p.sessions.Retrieve(source, p.SessionDuration)
+	session, name, err := p.sessions.Retrieve(source, p.SessionDuration)
+	p.defaultRoleSessionName = name
 	if err != nil {
 		session, err = p.getSamlSessionCreds()
 		if err != nil {
 			return credentials.Value{}, err
 		}
-		p.sessions.Store(source, session, p.SessionDuration)
+		p.sessions.Store(source, p.roleSessionName(), session, p.SessionDuration)
 	}
 
 	log.Debugf(" Using session %s, expires in %s",


### PR DESCRIPTION
We've noticed a behavior of `aws-okta` that doesn't work with some of our IAM policies that rely on a person's username coming through each time they `AssumeRole` into one of our accounts. Also, it makes identifying people who use `aws-okta` in CloudTrail more difficult: their username shows up as a timestamp most of the time.

You can see this issue by running `aws sts get-caller-identity` twice in succession:

```
? thopkins -> ~ $ aws-okta exec my-account -- aws sts get-caller-identity
INFO[0001] Requesting MFA
Enter MFA Code: 000000
{
    "Account": "ACCOUNT_ID",
    "UserId": "SOMEID:thopkins",
    "Arn": "arn:aws:sts::ACCOUNT_ID:assumed-role/role/thopkins"
}
? thopkins -> ~ $ aws-okta exec my-account -- aws sts get-caller-identity
{
    "Account": "ACCOUNT_ID",
    "UserId": "SOMEID:1522780778660795625",
    "Arn": "arn:aws:sts::ACCOUNT_ID:assumed-role/role/1522780778660795625"
}
```

The value of the `Arn` field in those outputs is inconsistent, and this behavior is controlled, for one, in `lib.(*Provider).roleSessionName()`. 

```go
func (p *Provider) roleSessionName() string {
	if name := p.profiles[p.profile]["role_session_name"]; name != "" {
		return name
	}

	if p.defaultRoleSessionName != "" {
		return p.defaultRoleSessionName
	}

	// Try to work out a role name that will hopefully end up unique.
	return fmt.Sprintf("%d", time.Now().UTC().UnixNano())
}
```

The `defaultRoleSessionName` field is only ever set as a side-effect of Okta and AWS SAML authentication in `lib.(*Provider).getSamlSessionCreds()`, so if `aws-okta exec` finds unexpired credentials in your keychain, it will `sts.AssumeRole` to the destination AWS account of your choice with a `UnixNano()` timestamp as the session name.

This PR solves that issue by storing the session name in the keychain with the AWS session keychain values and then retrieving it later so, for my case, `aws-okta` will preserve my Okta username. 

I also considered splitting the Okta credentials into two keychain items so `aws-okta` could just read the Okta username whenever it needed without loading a password into memory, but... the upgrade path for that seemed disruptive.