### PR TITLE
Support file keyring backend

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -27,13 +27,7 @@ func add(cmd *cobra.Command, args []string) error {
 	if backend != "" {
 		allowedBackends = append(allowedBackends, keyring.BackendType(backend))
 	}
-	kr, err := keyring.Open(keyring.Config{
-		AllowedBackends:          allowedBackends,
-		KeychainTrustApplication: true,
-		// this keychain name is for backwards compatibility
-		ServiceName:             "aws-okta-login",
-		LibSecretCollectionName: "awsvault",
-	})
+	kr, err := lib.OpenKeyring(allowedBackends)
 
 	if err != nil {
 		log.Fatal(err)

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -110,13 +110,7 @@ func execRun(cmd *cobra.Command, args []string) error {
 		allowedBackends = append(allowedBackends, keyring.BackendType(backend))
 	}
 
-	kr, err := keyring.Open(keyring.Config{
-		AllowedBackends:          allowedBackends,
-		KeychainTrustApplication: true,
-		// this keychain name is for backwards compatibility
-		ServiceName:             "aws-okta-login",
-		LibSecretCollectionName: "awsvault",
-	})
+	kr, err := lib.OpenKeyring(allowedBackends)
 	if err != nil {
 		return err
 	}

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -62,13 +62,10 @@ func loginRun(cmd *cobra.Command, args []string) error {
 	if backend != "" {
 		allowedBackends = append(allowedBackends, keyring.BackendType(backend))
 	}
-	kr, err := keyring.Open(keyring.Config{
-		AllowedBackends:          allowedBackends,
-		KeychainTrustApplication: true,
-		// this keychain name is for backwards compatibility
-		ServiceName:             "aws-okta-login",
-		LibSecretCollectionName: "awsvault",
-	})
+	kr, err := lib.OpenKeyring(allowedBackends)
+	if err != nil {
+		return err
+	}
 
 	p, err := lib.NewProvider(kr, profile, opts)
 	if err != nil {

--- a/lib/keyring.go
+++ b/lib/keyring.go
@@ -1,0 +1,23 @@
+package lib
+
+import (
+	"github.com/99designs/keyring"
+)
+
+func keyringPrompt(prompt string) (string, error) {
+	return Prompt(prompt, true)
+}
+
+func OpenKeyring(allowedBackends []keyring.BackendType) (kr keyring.Keyring, err error) {
+	kr, err = keyring.Open(keyring.Config{
+		AllowedBackends:          allowedBackends,
+		KeychainTrustApplication: true,
+		// this keychain name is for backwards compatibility
+		ServiceName:             "aws-okta-login",
+		LibSecretCollectionName: "awsvault",
+		FileDir:                 "~/.aws-okta/",
+		FilePasswordFunc:        keyringPrompt,
+	})
+
+	return
+}


### PR DESCRIPTION
Not ideal, because it requires supplying the keyring password
for every operation, but useful in situations where access to
more powerful keyrings are not available.

Addresses #37.