### PR TITLE
Update README to mention govendor

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ You can install with:
 $ go get github.com/segmentio/aws-okta
 ```
 
+You may have to update the vendor packages if you get errors in build. If you don't have govendor installed, please install it.
+
+``` bash
+$ cd $GOPATH/src/github.com/segmentio/aws-okta
+$ govendor sync
+$ go install
+```
+
 ## Usage
 
 ### Adding Okta credentials


### PR DESCRIPTION
I'm not sure if this is a better idea to tell people to `go vendor` or just vendor everything for master anyway. I made an issue #40 after running into this, so perhaps the best way to avoid builds breaking and `go get` to work nicely is to vendor the required versions when merging to master?

I just think `go get` failing is a bad experience for people trying to use the tool