### PR TITLE
Update readme to match config parsing code

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,11 @@ role_arn = arn:aws:iam::<account-id>:role/<okta-role-name>
 [profile integrations-auth]
 # This is a distinct Okta App
 aws_saml_url = home/amazon_aws/woezQTbGWUaLSrYDvINU/214
-arn:aws:iam::<account-id>:role/<okta-role-name>
+role_arn = arn:aws:iam::<account-id>:role/<okta-role-name>
 
 [profile vendor]
 # This profile uses the "integrations-auth" Okta app combined with secondary role assumption
-source = integrations-auth
+source_profile = integrations-auth
 role_arn = arn:aws:iam::<account-id>:role/<secondary-role-name>
 ```
 


### PR DESCRIPTION
The README regarding config appears to have drifted from the code, as
one must use 'source_profile' to indicate which role one uses as a hub
to assume another. This commit updates the README example with the
proper config key.

Also, 'role_arn' is added to the integrations-auth example profile, as
it is required.