### PR TITLE
Allows for form based Duo Authentication Fixes #26

### DIFF
--- a/lib/duo.go
+++ b/lib/duo.go
@@ -6,6 +6,10 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+
+	uniformResourceLocator "net/url"
+
+	"golang.org/x/net/html"
 )
 
 type DuoClient struct {
@@ -64,7 +68,7 @@ func (d *DuoClient) ChallengeU2f() (err error) {
 
 	tx = strings.Split(d.Signature, ":")[0]
 
-	sid, err = d.DoAuth(tx)
+	sid, err = d.DoAuth(tx, "", "")
 	if err != nil {
 		return
 	}
@@ -96,9 +100,13 @@ func (d *DuoClient) ChallengeU2f() (err error) {
 // DoAuth sends a POST request to the Duo /frame/web/v1/auth endpoint.
 // The request will not follow the redirect and retrieve the location from the HTTP header.
 // From the Location we get the Duo Session ID (sid) required for the rest of the communication.
+// In some integrations of Duo, an empty POST to the Duo /frame/web/v1/auth endpoint will return
+// StatusOK with a form of hidden inputs. In that case, we redo the POST with data from the
+// hidden inputs, which triggers the usual redirect/location flow and allows for a successful
+// authentication.
 //
 // The function will return the sid
-func (d *DuoClient) DoAuth(tx string) (sid string, err error) {
+func (d *DuoClient) DoAuth(tx string, inputSid string, inputCertsURL string) (sid string, err error) {
 	var req *http.Request
 	var location string
 
@@ -113,7 +121,13 @@ func (d *DuoClient) DoAuth(tx string) (sid string, err error) {
 		},
 	}
 
-	req, err = http.NewRequest("POST", url, nil)
+	data := uniformResourceLocator.Values{}
+	if inputSid != "" && inputCertsURL != "" {
+		data.Set("sid", inputSid)
+		data.Set("certs_url", inputCertsURL)
+	}
+
+	req, err = http.NewRequest("POST", url, strings.NewReader(data.Encode()))
 	if err != nil {
 		return
 	}
@@ -134,6 +148,14 @@ func (d *DuoClient) DoAuth(tx string) (sid string, err error) {
 		} else {
 			err = fmt.Errorf("Location not part of the auth header. Authentication failed ?")
 		}
+	} else if res.StatusCode == http.StatusOK && inputCertsURL == "" && inputSid == "" {
+		doc, err := html.Parse(res.Body)
+		if err != nil {
+			err = fmt.Errorf("Can't parse response")
+		}
+		sid, _ = GetNode(doc, "sid")
+		certsURL, _ := GetNode(doc, "certs_url")
+		sid, err = d.DoAuth(tx, sid, certsURL)
 	} else {
 		err = fmt.Errorf("Request failed or followed redirect: %d", res.StatusCode)
 	}

--- a/lib/utils.go
+++ b/lib/utils.go
@@ -58,7 +58,7 @@ func ParseSAML(body []byte, resp *SAMLAssertion) (err error) {
 		return
 	}
 
-	val, _ = GetNode(doc)
+	val, _ = GetNode(doc, "SAMLResponse")
 	if val != "" {
 		resp.RawData = []byte(val)
 		val = strings.Replace(val, "&#x2b;", "+", -1)
@@ -74,22 +74,21 @@ func ParseSAML(body []byte, resp *SAMLAssertion) (err error) {
 	return
 }
 
-func GetNode(n *html.Node) (val string, node *html.Node) {
-	var isSAML bool
+func GetNode(n *html.Node, name string) (val string, node *html.Node) {
+	var isMatch bool
 	if n.Type == html.ElementNode && n.Data == "input" {
 		for _, a := range n.Attr {
-			if a.Key == "name" && a.Val == "SAMLResponse" {
-				isSAML = true
+			if a.Key == "name" && a.Val == name {
+				isMatch = true
 			}
-			if a.Key == "value" && isSAML {
+			if a.Key == "value" && isMatch {
 				val = a.Val
 			}
 		}
 	}
-
 	if node == nil || val == "" {
 		for c := n.FirstChild; c != nil; c = c.NextSibling {
-			val, node = GetNode(c)
+			val, node = GetNode(c, name)
 			if val != "" {
 				return
 			}


### PR DESCRIPTION
In some integrations, it appears that hitting /frame/web/v1/auth with an
empty POST will not result in a 302, as expected, but returns a 200,
with a response body that contains a form with hidden input fields, sid
and certs_url. In order to continue with authentication, this form data
must be POSTed to the same /frame/web/v1/auth, which then triggers the
already handled 302 redirect flow.

This commit adds a branch to DoAuth where on StatusOK, we parse out the
values of the sid and certs_url inputs. These values are then passed
recursively to DoAuth again, so that another pass through the function
may submit these values and handle the expected 302 redirect flow. This
was found to be the order of operations needed from chrome dev tools
inspection of the iframe API calls, and it is working for our
integration setup.

It was attempted to use the form's sid value instead of trying to get it
from the 302 redirect location, but that resulted in a 403 Forbidden
from DoPrompt.

Also, GetNode has been generalized, in order to reuse the input form
parsing for sid and certs_url in addition to SAMLResponse.