### PR TITLE
Fix issuer name

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -159,7 +159,7 @@ func loginRun(cmd *cobra.Command, args []string) error {
 	}
 
 	loginURL := fmt.Sprintf(
-		"https://signin.aws.amazon.com/federation?Action=login&Issuer=aws-vault&Destination=%s&SigninToken=%s",
+		"https://signin.aws.amazon.com/federation?Action=login&Issuer=aws-okta&Destination=%s&SigninToken=%s",
 		url.QueryEscape(destination),
 		url.QueryEscape(signinToken),
 	)


### PR DESCRIPTION
Changed vault -> Okta. Minor thing but confused me slightly when I got this page after timeout in AWS;

"Amazon Web Services Sign In
Your session has expired.To start a new session, click the link provided by your administrator:aws-vault To logout, click here"