### PR TITLE
Add an AWS_OKTA_PROFILE env attribute

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -144,6 +144,7 @@ func execRun(cmd *cobra.Command, args []string) error {
 	env.Unset("AWS_CREDENTIAL_FILE")
 	env.Unset("AWS_DEFAULT_PROFILE")
 	env.Unset("AWS_PROFILE")
+	env.Unset("AWS_OKTA_PROFILE")
 
 	if region, ok := profiles[profile]["region"]; ok {
 		env.Set("AWS_DEFAULT_REGION", region)
@@ -152,6 +153,7 @@ func execRun(cmd *cobra.Command, args []string) error {
 
 	env.Set("AWS_ACCESS_KEY_ID", creds.AccessKeyID)
 	env.Set("AWS_SECRET_ACCESS_KEY", creds.SecretAccessKey)
+	env.Set("AWS_OKTA_PROFILE", profile)
 
 	if creds.SessionToken != "" {
 		env.Set("AWS_SESSION_TOKEN", creds.SessionToken)


### PR DESCRIPTION
Useful for when you have tooling that wants to know which role you're running in.

We don't want to use AWS_PROFILE, since that's significant to some tools.
Instead, add an AWS_OKTA_PROFILE env var, which is the name of the profile being used.