### PR TITLE
add a `list` command

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -113,7 +113,7 @@ func execRun(cmd *cobra.Command, args []string) error {
 	}
 
 	if _, ok := profiles[profile]; !ok {
-		return fmt.Errorf("Profile '%s' not found in your aws config", profile)
+		return fmt.Errorf("Profile '%s' not found in your aws config. Use list command to see configured profiles.", profile)
 	}
 
 	// check for an assume_role_ttl in the profile if we don't have a more explicit one

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"sort"
 	"text/tabwriter"
 
 	analytics "github.com/segmentio/analytics-go"
@@ -32,11 +33,20 @@ func listRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Let's sort this list of profiles so we can have some more deterministic output:
+	var profileNames []string
+
+	for profile := range profiles {
+		profileNames = append(profileNames, profile)
+	}
+
+	sort.Strings(profileNames)
+
 	w := new(tabwriter.Writer)
 	w.Init(os.Stdout, 0, 8, 2, '\t', 0)
-	fmt.Fprintln(w, "profile\tarn\tsource_role\t")
-	fmt.Fprintln(w, "---\t---\t---\t")
-	for profile, v := range profiles {
+	fmt.Fprintln(w, "PROFILE\tARN\tSOURCE_ROLE\t")
+	for _, profile := range profileNames {
+		v := profiles[profile]
 		if role, exist := v["role_arn"]; exist {
 			fmt.Fprintf(w, "%s\t%s\t%s\n", profile, role, v["source_profile"])
 		}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -38,10 +38,7 @@ func listRun(cmd *cobra.Command, args []string) error {
 	fmt.Fprintln(w, "---\t---\t---\t")
 	for profile, v := range profiles {
 		if role, exist := v["role_arn"]; exist {
-			if src, exist := v["source_profile"]; exist {
-				s := fmt.Sprintf("%s\t%s\t%s\t", profile, role, src)
-				fmt.Fprintln(w, s)
-			}
+			fmt.Fprintf(w, "%s\t%s\t%s\n", profile, role, v["source_profile"])
 		}
 	}
 	w.Flush()

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	analytics "github.com/segmentio/analytics-go"
+	"github.com/segmentio/aws-okta/lib"
+	"github.com/spf13/cobra"
+)
+
+// listCmd represents the list command
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "list will show you the profiles currently configured",
+	RunE:  listRun,
+}
+
+func init() {
+	RootCmd.AddCommand(listCmd)
+}
+
+func listRun(cmd *cobra.Command, args []string) error {
+	config, err := lib.NewConfigFromEnv()
+	if err != nil {
+		return err
+	}
+
+	profiles, err := config.Parse()
+	if err != nil {
+		return err
+	}
+
+	w := new(tabwriter.Writer)
+	w.Init(os.Stdout, 0, 8, 2, '\t', 0)
+	fmt.Fprintln(w, "profile\tarn\tsource_role\t")
+	fmt.Fprintln(w, "---\t---\t---\t")
+	for profile, v := range profiles {
+		if role, exist := v["role_arn"]; exist {
+			if src, exist := v["source_profile"]; exist {
+				s := fmt.Sprintf("%s\t%s\t%s\t", profile, role, src)
+				fmt.Fprintln(w, s)
+			}
+		}
+	}
+	w.Flush()
+
+	if analyticsEnabled && analyticsClient != nil {
+		analyticsClient.Enqueue(analytics.Track{
+			UserId: username,
+			Event:  "Listed Profiles",
+			Properties: analytics.NewProperties().
+				Set("backend", backend).
+				Set("aws-okta-version", version).
+				Set("profile-count", len(profiles)).
+				Set("command", "list"),
+		})
+	}
+	return nil
+}


### PR DESCRIPTION
I can never remember the names of the profiles I have configured, so this command will list them for you.

Caveat: It assumes you only care about profiles that are assuming from another role; it only lists profiles that have a source_profile.