### PR TITLE
Use stderr for passphrase prompt

### DIFF
--- a/lib/keyring.go
+++ b/lib/keyring.go
@@ -1,11 +1,13 @@
 package lib
 
 import (
+	"os"
+
 	"github.com/99designs/keyring"
 )
 
 func keyringPrompt(prompt string) (string, error) {
-	return Prompt(prompt, true)
+	return PromptWithOutput(prompt, true, os.Stderr)
 }
 
 func OpenKeyring(allowedBackends []keyring.BackendType) (kr keyring.Keyring, err error) {

--- a/lib/prompt.go
+++ b/lib/prompt.go
@@ -11,7 +11,13 @@ import (
 )
 
 func Prompt(prompt string, sensitive bool) (string, error) {
-	fmt.Printf("%s: ", prompt)
+	return PromptWithOutput(prompt, sensitive, os.Stdout)
+}
+
+func PromptWithOutput(prompt string, sensitive bool, output *os.File) (string, error) {
+	fmt.Fprintf(output, "%s: ", prompt)
+	defer fmt.Fprintf(output, "\n")
+
 	if sensitive {
 		var input []byte
 		input, err := terminal.ReadPassword(int(syscall.Stdin))


### PR DESCRIPTION
This allows redirecting the output of exec without the prompt getting in the way.