### PR TITLE
fix for duo empty result_url

### DIFF
--- a/lib/duo.go
+++ b/lib/duo.go
@@ -242,7 +242,11 @@ func (d *DuoClient) DoStatus(txid, sid string) (auth string, err error) {
 	err = json.NewDecoder(res.Body).Decode(&status)
 
 	if status.Response.Result == "SUCCESS" {
-		auth, err = d.DoRedirect(status.Response.ResultURL, sid)
+		if status.Response.ResultURL != "" {
+			auth, err = d.DoRedirect(status.Response.ResultURL, sid)
+		} else if status.Response.Cookie != ""  {
+			auth = status.Response.Cookie
+		}
 	}
 	return
 }

--- a/lib/duo.go
+++ b/lib/duo.go
@@ -244,7 +244,7 @@ func (d *DuoClient) DoStatus(txid, sid string) (auth string, err error) {
 	if status.Response.Result == "SUCCESS" {
 		if status.Response.ResultURL != "" {
 			auth, err = d.DoRedirect(status.Response.ResultURL, sid)
-		} else if status.Response.Cookie != ""  {
+		} else {
 			auth = status.Response.Cookie
 		}
 	}


### PR DESCRIPTION
if result_url is empty use existing cookie (if not empty)