### PR TITLE
Document: Don't append .okta.com to org name

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ $ go get github.com/segmentio/aws-okta
 $ aws-okta add
 ```
 
-This will prompt you for your Okta organization, username, and password.  These credentials will then be stored in your keyring for future use.
+This will prompt you for your Okta organization, username, and password.  These credentials will then be stored in your keyring for future use.   
+Note: Don't append ".okta.com" to your organization name, it is automatically added by `aws-okta`.
+
 
 ### Exec
 


### PR DESCRIPTION
If you have used other okta aws cli tools such as https://github.com/oktadeveloper/okta-aws-cli-assume-role - you might assume that you need to append .okta.com" to your organization name.

```
# incorrect usage
$ aws-okta add
Okta organization: mycompany.okta.com
Okta username: elliotmoore
Okta password:
INFO[0014] Added credentials for user elliotmoore
```
Results in: 
```
$ aws-okta login blah
Failed to authenticate with okta.  Please check that your credentials have been set correctly with `aws-okta add`
```

making clear that organization name should not be appended with .okta.com
as its already added here: https://github.com/segmentio/aws-okta/blob/master/lib/okta.go#L72

```
# correct usage
Okta organization: mycompany
```
Perhaps a better PR would warn the user during `aws-okta add` or ignore if exists.
For now this open PR might save somebody some time :-)