### PR TITLE
Add README update to show support for EKS and Kubectl.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,19 @@ Global Flags:
   -d, --debug            Enable debug logging
 ```
 
+### Exec for EKS and Kubernetes
+
+`aws-okta` can also be used to authenticate `kubectl` to your AWS EKS cluster. Assuming you have [installed `kubectl`](https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html), [setup your kubeconfig](https://docs.aws.amazon.com/eks/latest/userguide/create-kubeconfig.html) and [installed `aws-iam-authenticator`](https://docs.aws.amazon.com/eks/latest/userguide/configure-kubectl.html), you can now access your EKS cluster with `kubectl`. Note that on a new clusters, your Okta cli user needs to be using the same assumed role as the one who created the cluster. Otherwise, your cluster needs to have been configured to allow your assumed role.
+
+```bash
+$ aws-okta exec <profile> -- kubectl version --short
+```
+
+Likewise, most Kubernetes projects should work, like Helm and Ark.
+
+```bash
+$ aws-okta exec <profile> -- helm version --short
+```
 
 ### Configuring your aws config
 


### PR DESCRIPTION
You solved a problem you didn't even know about. :) I had `aws-okta` working for `aws-cli`, but whenever I tried to access my EKS cluster with `kubectl`, it would fail since `aws-iam-authenticator` doesn't know anything about `aws-okta`.

This works so long as `aws-okta` uses ENV variables to authenticate with AWS.

Adding this info to README should increase SEO friendliness on the topic and help others like myself find it in the future as EKS gains traction.