### PR TITLE
Support Yubikey configured in Duo for 2FA

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,11 @@ jobs:
           command: |
             sudo make -f Makefile.tools nfpm-debian rpmbuild-debian
       - run:
+          name: Install libusb
+          command: |
+            sudo apt update -q
+            sudo apt install -yq libusb-dev
+      - run:
           name: Make distributables
           command: |
             make -f Makefile.release dist-linux
@@ -39,11 +44,11 @@ jobs:
       - run:
           name: Install tools
           command: |
-            # this is required for the u2f to work linux & for package_cloud :/
-            sudo apt update -q
-            sudo apt install -yq ruby ruby-dev build-essential libusb-1.0.0-dev libusb-dev
-            # fixes https://askubuntu.com/questions/872399/error-failed-to-build-gem-native-extension-when-trying-to-download-rubocop
             make -f Makefile.tools github-release
+            # this is all for package_cloud :/
+            sudo apt update -q
+            sudo apt install -yq ruby ruby-dev build-essential
+            # fixes https://askubuntu.com/questions/872399/error-failed-to-build-gem-native-extension-when-trying-to-download-rubocop
             sudo gem install rake
             sudo make -f Makefile.tools package_cloud
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,11 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Install linux dependencies - libusb
+          command:
+            sudo apt update -q
+            sudo apt install -yq libusb-dev libusb-1.0.0-dev
+      - run:
           name: Test
           command: |
             make test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,8 +41,8 @@ jobs:
           command: |
             make -f Makefile.tools github-release
             # this is all for package_cloud :/
-            sudo apt update -q 
-            sudo apt install -yq ruby ruby-dev build-essential
+            sudo apt update -q
+            sudo apt install -yq ruby ruby-dev build-essential libusb-1.0.0-dev libusb-dev
             # fixes https://askubuntu.com/questions/872399/error-failed-to-build-gem-native-extension-when-trying-to-download-rubocop
             sudo gem install rake
             sudo make -f Makefile.tools package_cloud

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - checkout
       - run:
           name: Install linux dependencies - libusb
-          command:
+          command: |
             sudo apt update -q
             sudo apt install -yq libusb-dev libusb-1.0.0-dev
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
           name: Install libusb
           command: |
             sudo apt update -q
-            sudo apt install -yq libusb-dev
+            sudo apt install -yq libusb-dev libusb-1.0.0-dev
       - run:
           name: Make distributables
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,11 +39,11 @@ jobs:
       - run:
           name: Install tools
           command: |
-            make -f Makefile.tools github-release
-            # this is all for package_cloud :/
+            # this is required for the u2f to work linux & for package_cloud :/
             sudo apt update -q
             sudo apt install -yq ruby ruby-dev build-essential libusb-1.0.0-dev libusb-dev
             # fixes https://askubuntu.com/questions/872399/error-failed-to-build-gem-native-extension-when-trying-to-download-rubocop
+            make -f Makefile.tools github-release
             sudo gem install rake
             sudo make -f Makefile.tools package_cloud
       - run:

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -68,7 +68,7 @@ func add(cmd *cobra.Command, args []string) error {
 		Password:     password,
 	}
 
-	if err := creds.Validate(); err != nil {
+	if err := creds.Validate(mfaDevice); err != nil {
 		log.Debugf("Failed to validate credentials: %s", err)
 		return ErrFailedToValidateCredentials
 	}

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -101,6 +101,7 @@ func execRun(cmd *cobra.Command, args []string) error {
 	}
 
 	opts := lib.ProviderOptions{
+		MFADevice:          mfaDevice,
 		Profiles:           profiles,
 		SessionDuration:    sessionTTL,
 		AssumeRoleDuration: assumeRoleTTL,

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -69,6 +69,7 @@ func loginRun(cmd *cobra.Command, args []string) error {
 	}
 
 	opts := lib.ProviderOptions{
+		MFADevice:          mfaDevice,
 		Profiles:           profiles,
 		SessionDuration:    sessionTTL,
 		AssumeRoleDuration: assumeRoleTTL,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,6 +20,11 @@ var (
 	ErrFailedToValidateCredentials = errors.New("Failed to validate credentials")
 )
 
+const (
+	// keep expected behavior pre-u2f with duo push
+	DefaultMFADevice = "phone1"
+)
+
 // global flags
 var (
 	backend           string
@@ -71,6 +76,8 @@ func prerun(cmd *cobra.Command, args []string) {
 		mfaDeviceFromEnv, ok := os.LookupEnv("AWS_OKTA_MFA_DEVICE")
 		if ok {
 			mfaDevice = mfaDeviceFromEnv
+		} else {
+			mfaDevice = DefaultMFADevice
 		}
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,6 +23,7 @@ var (
 // global flags
 var (
 	backend           string
+	mfaDevice         string
 	debug             bool
 	version           string
 	analyticsWriteKey string
@@ -66,6 +67,13 @@ func prerun(cmd *cobra.Command, args []string) {
 		}
 	}
 
+	if !cmd.Flags().Lookup("mfa-device").Changed {
+		mfaDeviceFromEnv, ok := os.LookupEnv("AWS_OKTA_MFA_DEVICE")
+		if ok {
+			mfaDevice = mfaDeviceFromEnv
+		}
+	}
+
 	if debug {
 		log.SetLevel(log.DebugLevel)
 	}
@@ -96,6 +104,7 @@ func init() {
 	for _, backendType := range keyring.AvailableBackends() {
 		backendsAvailable = append(backendsAvailable, string(backendType))
 	}
+	RootCmd.PersistentFlags().StringVarP(&mfaDevice, "mfa-device", "m", "phone1", "Device to use phone1, phone2 or token")
 	RootCmd.PersistentFlags().StringVarP(&backend, "backend", "b", "", fmt.Sprintf("Secret backend to use %s", backendsAvailable))
 	RootCmd.PersistentFlags().BoolVarP(&debug, "debug", "d", false, "Enable debug logging")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -104,7 +104,7 @@ func init() {
 	for _, backendType := range keyring.AvailableBackends() {
 		backendsAvailable = append(backendsAvailable, string(backendType))
 	}
-	RootCmd.PersistentFlags().StringVarP(&mfaDevice, "mfa-device", "m", "phone1", "Device to use phone1, phone2 or token")
+	RootCmd.PersistentFlags().StringVarP(&mfaDevice, "mfa-device", "m", "phone1", "Device to use phone1, phone2, u2f or token")
 	RootCmd.PersistentFlags().StringVarP(&backend, "backend", "b", "", fmt.Sprintf("Secret backend to use %s", backendsAvailable))
 	RootCmd.PersistentFlags().BoolVarP(&debug, "debug", "d", false, "Enable debug logging")
 }

--- a/lib/duo.go
+++ b/lib/duo.go
@@ -185,7 +185,8 @@ func (d *DuoClient) ChallengeU2f() (err error) {
 						log.Printf("Authentication succeeded, continuing")
 					} else if _, ok := err.(*u2fhost.TestOfUserPresenceRequiredError); ok {
 						if !prompted {
-							fmt.Println("\nTouch the flashing U2F device to authenticate...\n")
+							fmt.Println("Touch the flashing U2F device to authenticate...")
+							fmt.Println()
 						}
 						prompted = true
 					} else {

--- a/lib/duo.go
+++ b/lib/duo.go
@@ -200,12 +200,14 @@ func (d *DuoClient) ChallengeU2f(verificationHost string) (err error) {
 		//}
 	}
 
+	log.Printf("Device: %s", d.Device)
+
 	// So, turns out that if you call DoStatus in
 	// Duo's token mode, it will return an auth token
 	// immediately if successful, because it's a single check
 	// but for Push you get empty value and have to
 	// wait on second response post-push
-	if auth == "" {
+	if d.Device != "u2f" && d.Device != "token" {
 		// This one should block untile 2fa completed
 		auth, _, err = d.DoStatus(txid, sid)
 		if err != nil {

--- a/lib/duo.go
+++ b/lib/duo.go
@@ -111,7 +111,7 @@ func (d *DuoClient) getTrustedFacet(appId string) (facetResponse *FacetResponse,
 // call the callback url.
 //
 // TODO: Use a Context to gracefully shutdown the thing and have a nice timeout
-func (d *DuoClient) ChallengeU2f() (err error) {
+func (d *DuoClient) ChallengeU2f(verificationHost string) (err error) {
 	var sid, tx, txid, auth string
 	var status = StatusResp{}
 
@@ -156,13 +156,8 @@ func (d *DuoClient) ChallengeU2f() (err error) {
 		prompted := false
 		timeout := time.After(time.Second * 25)
 		interval := time.NewTicker(time.Millisecond * 250)
-		facet := ""
-		facetResponse, err := d.getTrustedFacet(status.Response.U2FSignRequest[0].AppID)
-		if err != nil {
-			return fmt.Errorf("failed to get trusted facets for u2f device. Err: %s", err)
-		}
-		// TODO: do more error checks
-		facet = facetResponse.TrustedFacets[0].Ids[0]
+		facet := "https://" + verificationHost
+		log.Debugf("Facet: %s", facet)
 		var req = &u2fhost.AuthenticateRequest{
 			Challenge: status.Response.U2FSignRequest[0].Challenge,
 			AppId:     status.Response.U2FSignRequest[0].AppID,

--- a/lib/okta.go
+++ b/lib/okta.go
@@ -280,7 +280,7 @@ func (o *OktaClient) postChallenge(payload []byte, oktaFactorProvider string, ok
 				go func() {
 					log.Debug("challenge u2f")
 					log.Info("Sending Push Notification...")
-					err := o.DuoClient.ChallengeU2f()
+					err := o.DuoClient.ChallengeU2f(f.Embedded.Verification.Host)
 					if err != nil {
 						errChan <- err
 					}

--- a/lib/okta.go
+++ b/lib/okta.go
@@ -33,6 +33,7 @@ type OktaClient struct {
 	Password        string
 	UserAuth        *OktaUserAuthn
 	DuoClient       *DuoClient
+	MFADevice       string
 	AccessKeyId     string
 	SecretAccessKey string
 	SessionToken    string
@@ -55,7 +56,7 @@ type OktaCreds struct {
 
 func (c *OktaCreds) Validate() error {
 	// OktaClient assumes we're doing some AWS SAML calls, but Validate doesn't
-	o, err := NewOktaClient(*c, "", "")
+	o, err := NewOktaClient(*c, "", "", "")
 	if err != nil {
 		return err
 	}
@@ -67,7 +68,7 @@ func (c *OktaCreds) Validate() error {
 	return nil
 }
 
-func NewOktaClient(creds OktaCreds, oktaAwsSAMLUrl string, sessionCookie string) (*OktaClient, error) {
+func NewOktaClient(creds OktaCreds, oktaAwsSAMLUrl string, sessionCookie string, mfaDevice string) (*OktaClient, error) {
 	base, err := url.Parse(fmt.Sprintf(
 		"https://%s.%s", creds.Organization, OktaServer,
 	))
@@ -96,6 +97,7 @@ func NewOktaClient(creds OktaCreds, oktaAwsSAMLUrl string, sessionCookie string)
 		OktaAwsSAMLUrl: oktaAwsSAMLUrl,
 		CookieJar:      jar,
 		BaseURL:        base,
+		MFADevice:      mfaDevice,
 	}, nil
 }
 
@@ -217,7 +219,7 @@ func (o *OktaClient) preChallenge(oktaFactorId, oktaFactorType string) ([]byte, 
 	var mfaCode string
 	var err error
 	//Software and Hardware based OTP Tokens
-	if strings.Contains(oktaFactorType, "token") {
+	if strings.Contains(oktaFactorId, "token") {
 		log.Debug("Token MFA")
 		mfaCode, err = Prompt("Enter MFA Code", false)
 		if err != nil {
@@ -267,6 +269,7 @@ func (o *OktaClient) postChallenge(payload []byte, oktaFactorProvider string, ok
 					Host:       f.Embedded.Verification.Host,
 					Signature:  f.Embedded.Verification.Signature,
 					Callback:   f.Embedded.Verification.Links.Complete.Href,
+					Device:     o.MFADevice,
 					StateToken: o.UserAuth.StateToken,
 				}
 
@@ -289,15 +292,16 @@ func (o *OktaClient) postChallenge(payload []byte, oktaFactorProvider string, ok
 		for o.UserAuth.Status != "SUCCESS" {
 			select {
 			case duoErr := <-errChan:
+				log.Printf("Err: %s", duoErr)
 				if duoErr != nil {
-					return errors.New("Failed Duo challenge")
+					return fmt.Errorf("Failed Duo challenge. Err: %s", duoErr)
 				}
 			default:
 				err := o.Get("POST", "api/v1/authn/factors/"+oktaFactorId+"/verify",
 					payload, &o.UserAuth, "json",
 				)
 				if err != nil {
-					return err
+					return fmt.Errorf("Failed authn verification for okta. Err: %s", err)
 				}
 			}
 			time.Sleep(2 * time.Second)
@@ -441,6 +445,7 @@ type OktaProvider struct {
 	ProfileARN      string
 	SessionDuration time.Duration
 	OktaAwsSAMLUrl  string
+	MFADevice       string
 }
 
 func (p *OktaProvider) Retrieve() (sts.Credentials, string, error) {
@@ -463,7 +468,7 @@ func (p *OktaProvider) Retrieve() (sts.Credentials, string, error) {
 		sessionCookie = string(cookieItem.Data)
 	}
 
-	oktaClient, err := NewOktaClient(oktaCreds, p.OktaAwsSAMLUrl, sessionCookie)
+	oktaClient, err := NewOktaClient(oktaCreds, p.OktaAwsSAMLUrl, sessionCookie, p.MFADevice)
 	if err != nil {
 		return sts.Credentials{}, "", err
 	}

--- a/lib/okta.go
+++ b/lib/okta.go
@@ -54,9 +54,9 @@ type OktaCreds struct {
 	Password     string
 }
 
-func (c *OktaCreds) Validate() error {
+func (c *OktaCreds) Validate(mfaDevice string) error {
 	// OktaClient assumes we're doing some AWS SAML calls, but Validate doesn't
-	o, err := NewOktaClient(*c, "", "", "")
+	o, err := NewOktaClient(*c, "", "", mfaDevice)
 	if err != nil {
 		return err
 	}

--- a/lib/provider.go
+++ b/lib/provider.go
@@ -25,6 +25,7 @@ const (
 )
 
 type ProviderOptions struct {
+	MFADevice          string
 	SessionDuration    time.Duration
 	AssumeRoleDuration time.Duration
 	ExpiryWindow       time.Duration
@@ -158,6 +159,7 @@ func (p *Provider) getSamlSessionCreds() (sts.Credentials, error) {
 	}
 
 	provider := OktaProvider{
+		MFADevice:       p.ProviderOptions.MFADevice,
 		Keyring:         p.keyring,
 		ProfileARN:      profileARN,
 		SessionDuration: p.SessionDuration,

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -269,6 +269,12 @@
 			"revisionTime": "2017-01-28T05:16:51Z"
 		},
 		{
+			"checksumSHA1": "YRLjKfRVsaCD7vydWyPOSHho3uc=",
+			"path": "github.com/marshallbrekka/go.hid",
+			"revision": "2c1c4616a9e71d08897a583653abca4b4ac55028",
+			"revisionTime": "2016-12-27T00:27:17Z"
+		},
+		{
 			"checksumSHA1": "V/quM7+em2ByJbWBLOsEwnY3j/Q=",
 			"path": "github.com/mitchellh/go-homedir",
 			"revision": "b8bc1bf767474819792c23f32d8286a45736f1c6",
@@ -311,6 +317,12 @@
 			"path": "github.com/vaughan0/go-ini",
 			"revision": "a98ad7ee00ec53921f08832bc06ecf7fd600e6a1",
 			"revisionTime": "2013-09-23T14:52:12Z"
+		},
+		{
+			"checksumSHA1": "slWRUAScaoYv/QZC1GOI2oxNSPo=",
+			"path": "github.com/vitaminwater/cgo.wchar",
+			"revision": "5dd6f4be3f2a8c064325fe63439975cf37a8aa1d",
+			"revisionTime": "2016-03-20T12:33:32Z"
 		},
 		{
 			"checksumSHA1": "LAL/r7KfCdqp4M6MM13+7NWsUNc=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -257,6 +257,18 @@
 			"revisionTime": "2017-01-28T05:16:51Z"
 		},
 		{
+			"checksumSHA1": "AlTh58nkLM7k2dzV0ZKGy0/N+wA=",
+			"path": "github.com/marshallbrekka/go-u2fhost/bytes",
+			"revision": "72b0e7a3f583583996b3b382d2dfaa81fdc4b82c",
+			"revisionTime": "2017-01-28T05:16:51Z"
+		},
+		{
+			"checksumSHA1": "gZLz/NbmeZfwd09MMZJxCC5p9nE=",
+			"path": "github.com/marshallbrekka/go-u2fhost/hid",
+			"revision": "72b0e7a3f583583996b3b382d2dfaa81fdc4b82c",
+			"revisionTime": "2017-01-28T05:16:51Z"
+		},
+		{
 			"checksumSHA1": "V/quM7+em2ByJbWBLOsEwnY3j/Q=",
 			"path": "github.com/mitchellh/go-homedir",
 			"revision": "b8bc1bf767474819792c23f32d8286a45736f1c6",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -269,6 +269,12 @@
 			"revisionTime": "2017-01-28T05:16:51Z"
 		},
 		{
+			"checksumSHA1": "YRLjKfRVsaCD7vydWyPOSHho3uc=",
+			"path": "github.com/marshallbrekka/go.hid",
+			"revision": "2c1c4616a9e71d08897a583653abca4b4ac55028",
+			"revisionTime": "2016-12-27T00:27:17Z"
+		},
+		{
 			"checksumSHA1": "V/quM7+em2ByJbWBLOsEwnY3j/Q=",
 			"path": "github.com/mitchellh/go-homedir",
 			"revision": "b8bc1bf767474819792c23f32d8286a45736f1c6",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -251,6 +251,12 @@
 			"revisionTime": "2018-08-01T17:02:00Z"
 		},
 		{
+			"checksumSHA1": "5gr/jp09qcOuCFNuh5qwXkjB3lk=",
+			"path": "github.com/marshallbrekka/go-u2fhost",
+			"revision": "72b0e7a3f583583996b3b382d2dfaa81fdc4b82c",
+			"revisionTime": "2017-01-28T05:16:51Z"
+		},
+		{
 			"checksumSHA1": "V/quM7+em2ByJbWBLOsEwnY3j/Q=",
 			"path": "github.com/mitchellh/go-homedir",
 			"revision": "b8bc1bf767474819792c23f32d8286a45736f1c6",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -269,12 +269,6 @@
 			"revisionTime": "2017-01-28T05:16:51Z"
 		},
 		{
-			"checksumSHA1": "YRLjKfRVsaCD7vydWyPOSHho3uc=",
-			"path": "github.com/marshallbrekka/go.hid",
-			"revision": "2c1c4616a9e71d08897a583653abca4b4ac55028",
-			"revisionTime": "2016-12-27T00:27:17Z"
-		},
-		{
 			"checksumSHA1": "V/quM7+em2ByJbWBLOsEwnY3j/Q=",
 			"path": "github.com/mitchellh/go-homedir",
 			"revision": "b8bc1bf767474819792c23f32d8286a45736f1c6",


### PR DESCRIPTION
This breaks a few abstractions -- and hence warrants some explanation
The Duo MFA flow in aws-okta is predicated on something like this

1. user pings okta
2. if duo, call duo API /frame/prompt which sends a push
3. this is where we have problem.. with yubikey vs push
-- instead of async waiting, yubikey can write directly to stdin and
continue, because the initial factor call wants the passcode to be
passed in
4. Then in Status call turns out the first status call returns empty
for Push but second can wait. It's opposite for Yubikey

The next step is on how to give the users a choice. I thought of few
options and settled on a flag, where the user flow is - X method
didn't work, I'll try another one. But because of the providers
nesting and calling OktaClient, it MFADevice field had to be added to
bunch of structures, where they feel very leaky. The structure doesn't
lend itself to anything more clever currently.

So the flag I introduced is --mfa-device which defaults to phone1 so
users expecting previous behavior can continue working as
is. Additionally this introduces another environment variable
AWS_OKTA_MFA_DEVICE which can be token, phone1, phone2, whatever Duo
will accept.

Alternate and a maybe architecturally cleaner way might be to ask user
which factor they want. But picking every single time when a flag
would do seems inefficient too.