### PR TITLE
Use log.Debugf instead of log.Debug

### DIFF
--- a/lib/okta.go
+++ b/lib/okta.go
@@ -447,7 +447,7 @@ func (p *OktaProvider) Retrieve() (sts.Credentials, string, error) {
 	log.Debug("using okta provider")
 	item, err := p.Keyring.Get("okta-creds")
 	if err != nil {
-		log.Debug("couldnt get okta creds from keyring: %s", err)
+		log.Debugf("couldnt get okta creds from keyring: %s", err)
 		return sts.Credentials{}, "", err
 	}
 


### PR DESCRIPTION
I'm having this output when `keyring.Get` fails:
```
DEBU[0000] couldnt get okta creds from keyring: %sunexpected end of JSON input
```

Cause `%s` is not being interpolated.