### PR TITLE
[WIP] Add support for multiple saml urls

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -12,6 +12,7 @@ import (
 	"github.com/99designs/keyring"
 	analytics "github.com/segmentio/analytics-go"
 	"github.com/segmentio/aws-okta/lib"
+	"github.com/segmentio/aws-okta/lib/legacy"
 	"github.com/spf13/cobra"
 )
 
@@ -102,7 +103,7 @@ func execRun(cmd *cobra.Command, args []string) error {
 		commandArgs = commandPart[1:]
 	}
 
-	config, err := lib.NewConfigFromEnv()
+	config, err := legacy.NewConfigFromEnv()
 	if err != nil {
 		return err
 	}
@@ -123,7 +124,7 @@ func execRun(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	opts := lib.ProviderOptions{
+	opts := legacy.ProviderOptions{
 		Profiles:           profiles,
 		SessionDuration:    sessionTTL,
 		AssumeRoleDuration: assumeRoleTTL,
@@ -151,7 +152,7 @@ func execRun(cmd *cobra.Command, args []string) error {
 		})
 	}
 
-	p, err := lib.NewProvider(kr, profile, opts)
+	p, err := legacy.NewProvider(kr, profile, opts)
 	if err != nil {
 		return err
 	}

--- a/lib/legacy/config.go
+++ b/lib/legacy/config.go
@@ -1,0 +1,67 @@
+package legacy
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/mitchellh/go-homedir"
+	"github.com/vaughan0/go-ini"
+)
+
+type profiles map[string]map[string]string
+
+type config interface {
+	Parse() (profiles, error)
+}
+
+type fileConfig struct {
+	file string
+}
+
+func NewConfigFromEnv() (config, error) {
+	file := os.Getenv("AWS_CONFIG_FILE")
+	if file == "" {
+		home, err := homedir.Dir()
+		if err != nil {
+			return nil, err
+		}
+		file = filepath.Join(home, "/.aws/config")
+		if _, err := os.Stat(file); os.IsNotExist(err) {
+			file = ""
+		}
+	}
+	return &fileConfig{file: file}, nil
+}
+
+func (c *fileConfig) Parse() (profiles, error) {
+	if c.file == "" {
+		return nil, nil
+	}
+
+	log.Debugf("Parsing config file %s", c.file)
+	f, err := ini.LoadFile(c.file)
+	if err != nil {
+		return nil, fmt.Errorf("Error parsing config file %q: %v", c.file, err)
+	}
+
+	profiles := profiles{"okta": map[string]string{}}
+	for sectionName, section := range f {
+		profiles[strings.TrimPrefix(sectionName, "profile ")] = section
+	}
+
+	return profiles, nil
+}
+
+// sourceProfile returns either the defined source_profile or p if none exists
+func sourceProfile(p string, from profiles) string {
+	if conf, ok := from[p]; ok {
+		if source := conf["source_profile"]; source != "" {
+			return source
+		}
+	}
+	return p
+}

--- a/lib/legacy/provider.go
+++ b/lib/legacy/provider.go
@@ -1,0 +1,211 @@
+package legacy
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/99designs/keyring"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/segmentio/aws-okta/lib"
+)
+
+const (
+	MaxSessionDuration    = time.Hour * 36
+	MinSessionDuration    = time.Minute * 15
+	MinAssumeRoleDuration = time.Minute * 15
+	MaxAssumeRoleDuration = time.Hour * 12
+
+	DefaultSessionDuration    = time.Hour * 4
+	DefaultAssumeRoleDuration = time.Minute * 15
+)
+
+type ProviderOptions struct {
+	SessionDuration    time.Duration
+	AssumeRoleDuration time.Duration
+	ExpiryWindow       time.Duration
+	Profiles           profiles
+}
+
+func (o ProviderOptions) Validate() error {
+	if o.SessionDuration < MinSessionDuration {
+		return errors.New("Minimum session duration is " + MinSessionDuration.String())
+	} else if o.SessionDuration > MaxSessionDuration {
+		return errors.New("Maximum session duration is " + MaxSessionDuration.String())
+	}
+	if o.AssumeRoleDuration < MinAssumeRoleDuration {
+		return errors.New("Minimum duration for assumed roles is " + MinAssumeRoleDuration.String())
+	} else if o.AssumeRoleDuration > MaxAssumeRoleDuration {
+		log.Println(o.AssumeRoleDuration)
+		return errors.New("Maximum duration for assumed roles is " + MaxAssumeRoleDuration.String())
+	}
+
+	return nil
+}
+
+func (o ProviderOptions) ApplyDefaults() ProviderOptions {
+	if o.AssumeRoleDuration == 0 {
+		o.AssumeRoleDuration = DefaultAssumeRoleDuration
+	}
+	if o.SessionDuration == 0 {
+		o.SessionDuration = DefaultSessionDuration
+	}
+	return o
+}
+
+type Provider struct {
+	credentials.Expiry
+	ProviderOptions
+	profile                string
+	expires                time.Time
+	keyring                keyring.Keyring
+	sessions               *KeyringSessions
+	profiles               profiles
+	defaultRoleSessionName string
+}
+
+func NewProvider(k keyring.Keyring, profile string, opts ProviderOptions) (*Provider, error) {
+	opts = opts.ApplyDefaults()
+	if err := opts.Validate(); err != nil {
+		return nil, err
+	}
+	return &Provider{
+		ProviderOptions: opts,
+		keyring:         k,
+		sessions:        &KeyringSessions{k, opts.Profiles},
+		profile:         profile,
+		profiles:        opts.Profiles,
+	}, nil
+}
+
+func (p *Provider) Retrieve() (credentials.Value, error) {
+
+	window := p.ExpiryWindow
+	if window == 0 {
+		window = time.Minute * 5
+	}
+
+	source := sourceProfile(p.profile, p.profiles)
+	session, name, err := p.sessions.Retrieve(source, p.SessionDuration)
+	p.defaultRoleSessionName = name
+	if err != nil {
+		session, err = p.getSamlSessionCreds()
+		if err != nil {
+			return credentials.Value{}, err
+		}
+		p.sessions.Store(source, p.roleSessionName(), session, p.SessionDuration)
+	}
+
+	log.Debugf(" Using session %s, expires in %s",
+		(*session.AccessKeyId)[len(*session.AccessKeyId)-4:],
+		session.Expiration.Sub(time.Now()).String())
+
+	// If sourceProfile returns the same source then we do not need to assume a
+	// second role. Not assuming a second role allows us to assume IDP enabled
+	// roles directly.
+	if p.profile != source {
+		if role, ok := p.profiles[p.profile]["role_arn"]; ok {
+			session, err = p.assumeRoleFromSession(session, role)
+			if err != nil {
+				return credentials.Value{}, err
+			}
+
+			log.Debugf("using role %s expires in %s",
+				(*session.AccessKeyId)[len(*session.AccessKeyId)-4:],
+				session.Expiration.Sub(time.Now()).String())
+		}
+	}
+
+	p.SetExpiration(*session.Expiration, window)
+	p.expires = *session.Expiration
+
+	value := credentials.Value{
+		AccessKeyID:     *session.AccessKeyId,
+		SecretAccessKey: *session.SecretAccessKey,
+		SessionToken:    *session.SessionToken,
+		ProviderName:    "okta",
+	}
+
+	return value, nil
+}
+
+func (p *Provider) getSamlURL(source string) (string, error) {
+	haystack := []string{p.profile, source, "okta"}
+	for _, profile := range haystack {
+		oktaAwsSAMLUrl, ok := p.profiles[profile]["aws_saml_url"]
+		if ok {
+			log.Debugf("Using aws_saml_url from profile: %s", profile)
+			return oktaAwsSAMLUrl, nil
+		}
+	}
+	return "", errors.New("aws_saml_url missing from ~/.aws/config")
+}
+
+func (p *Provider) getSamlSessionCreds() (sts.Credentials, error) {
+	source := sourceProfile(p.profile, p.profiles)
+	oktaAwsSAMLUrl, err := p.getSamlURL(source)
+	if err != nil {
+		return sts.Credentials{}, err
+	}
+
+	profileARN, ok := p.profiles[source]["role_arn"]
+	if !ok {
+		return sts.Credentials{}, errors.New("Source profile must provide `role_arn`")
+	}
+
+	provider := lib.OktaProvider{
+		Keyring:         p.keyring,
+		ProfileARN:      profileARN,
+		SessionDuration: p.SessionDuration,
+		OktaAwsSAMLUrl:  oktaAwsSAMLUrl,
+	}
+
+	creds, oktaUsername, err := provider.Retrieve()
+	if err != nil {
+		return sts.Credentials{}, err
+	}
+	p.defaultRoleSessionName = oktaUsername
+
+	return creds, nil
+}
+
+// assumeRoleFromSession takes a session created with an okta SAML login and uses that to assume a role
+func (p *Provider) assumeRoleFromSession(creds sts.Credentials, roleArn string) (sts.Credentials, error) {
+	client := sts.New(session.New(&aws.Config{Credentials: credentials.NewStaticCredentials(
+		*creds.AccessKeyId,
+		*creds.SecretAccessKey,
+		*creds.SessionToken,
+	)}))
+
+	input := &sts.AssumeRoleInput{
+		RoleArn:         aws.String(roleArn),
+		RoleSessionName: aws.String(p.roleSessionName()),
+		DurationSeconds: aws.Int64(int64(p.AssumeRoleDuration.Seconds())),
+	}
+
+	log.Debugf("Assuming role %s from session token", roleArn)
+	resp, err := client.AssumeRole(input)
+	if err != nil {
+		return sts.Credentials{}, err
+	}
+
+	return *resp.Credentials, nil
+}
+
+func (p *Provider) roleSessionName() string {
+	if name := p.profiles[p.profile]["role_session_name"]; name != "" {
+		return name
+	}
+
+	if p.defaultRoleSessionName != "" {
+		return p.defaultRoleSessionName
+	}
+
+	// Try to work out a role name that will hopefully end up unique.
+	return fmt.Sprintf("%d", time.Now().UTC().UnixNano())
+}

--- a/lib/legacy/sessions.go
+++ b/lib/legacy/sessions.go
@@ -1,0 +1,100 @@
+package legacy
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/99designs/keyring"
+	"github.com/aws/aws-sdk-go/service/sts"
+)
+
+type awsSession struct {
+	sts.Credentials
+	Name string
+}
+
+type KeyringSessions struct {
+	Keyring  keyring.Keyring
+	Profiles profiles
+}
+
+func NewKeyringSessions(k keyring.Keyring, p profiles) (*KeyringSessions, error) {
+	return &KeyringSessions{
+		Keyring:  k,
+		Profiles: p,
+	}, nil
+}
+
+func (s *KeyringSessions) key(profile string, duration time.Duration) string {
+	source := sourceProfile(profile, s.Profiles)
+	hasher := md5.New()
+	hasher.Write([]byte(duration.String()))
+
+	if p, ok := s.Profiles[profile]; ok {
+		enc := json.NewEncoder(hasher)
+		enc.Encode(p)
+	}
+
+	return fmt.Sprintf("%s session (%x)", source, hex.EncodeToString(hasher.Sum(nil))[0:10])
+}
+
+func (s *KeyringSessions) Retrieve(profile string, duration time.Duration) (sts.Credentials, string, error) {
+	var session awsSession
+	item, err := s.Keyring.Get(s.key(profile, duration))
+	if err != nil {
+		return session.Credentials, session.Name, err
+	}
+
+	if err = json.Unmarshal(item.Data, &session); err != nil {
+		return session.Credentials, session.Name, err
+	}
+
+	if session.Expiration.Before(time.Now()) {
+		return session.Credentials, session.Name, errors.New("Session is expired")
+	}
+
+	return session.Credentials, session.Name, nil
+}
+
+func (s *KeyringSessions) Store(profile string, sessionName string, creds sts.Credentials, duration time.Duration) error {
+	session := awsSession{Credentials: creds, Name: sessionName}
+	bytes, err := json.Marshal(session)
+	if err != nil {
+		return err
+	}
+
+	log.Debugf("Writing session for %s to keyring", profile)
+	s.Keyring.Set(keyring.Item{
+		Key:                         s.key(profile, duration),
+		Label:                       "aws session for " + profile,
+		Data:                        bytes,
+		KeychainNotTrustApplication: false,
+	})
+
+	return nil
+}
+
+func (s *KeyringSessions) Delete(profile string) (n int, err error) {
+	keys, err := s.Keyring.Keys()
+	if err != nil {
+		return n, err
+	}
+
+	for _, k := range keys {
+		if strings.HasPrefix(k, fmt.Sprintf("%s session", sourceProfile(profile, s.Profiles))) {
+			if err = s.Keyring.Remove(k); err != nil {
+				return n, err
+			}
+			n++
+		}
+	}
+
+	return
+}


### PR DESCRIPTION
⚠️ WIP

## What does this do?
This PR adds support for multiple Okta apps as a means of authenticating to specific account/roles in AWS.
* Moves the old provider / configuration logic out into legacy files
* Adds new recommended configuration via a `.yml` mapping of permission -> saml url
* Should update README

## Why is this important?
The current aws-okta workflow assume we have one SSO saml url as an entry point. Going forward we'd like to manage different account/roles in AWS as individual Okta apps, instead of using the current second assume role flow. This change allows for more granular user permission control via Okta instead of having to modify the config file and IAM permissions.
