### PR TITLE
Add ability to configure the Okta session key value that is stored in the keyring.

### DIFF
--- a/lib/okta.go
+++ b/lib/okta.go
@@ -24,8 +24,8 @@ import (
 )
 
 const (
-	OktaServerUs = "okta.com"
-	OktaServerEmea = "okta-emea.com"
+	OktaServerUs      = "okta.com"
+	OktaServerEmea    = "okta-emea.com"
 	OktaServerPreview = "oktapreview.com"
 	OktaServerDefault = OktaServerUs
 
@@ -61,7 +61,7 @@ type OktaCreds struct {
 	Organization string
 	Username     string
 	Password     string
-	Domain 		 string
+	Domain       string
 }
 
 func (c *OktaCreds) Validate(mfaDevice string) error {
@@ -80,12 +80,12 @@ func (c *OktaCreds) Validate(mfaDevice string) error {
 
 func getOktaDomain(region string) (string, error) {
 	switch region {
-		case "us":
-			return OktaServerUs, nil
-		case "emea":
-			return OktaServerEmea, nil
-		case "preview":
-			return OktaServerPreview, nil
+	case "us":
+		return OktaServerUs, nil
+	case "emea":
+		return OktaServerEmea, nil
+	case "preview":
+		return OktaServerPreview, nil
 	}
 	return "", fmt.Errorf("invalid region %s", region)
 }
@@ -126,14 +126,14 @@ func NewOktaClient(creds OktaCreds, oktaAwsSAMLUrl string, sessionCookie string,
 
 	return &OktaClient{
 		// Setting Organization for backwards compatibility
-		Organization:   	creds.Organization,
-		Username:       	creds.Username,
-		Password:       	creds.Password,
-		OktaAwsSAMLUrl: 	oktaAwsSAMLUrl,
-		CookieJar:      	jar,
-		BaseURL:        	base,
-		MFADevice:          mfaDevice,
-		Domain: 			domain,
+		Organization:   creds.Organization,
+		Username:       creds.Username,
+		Password:       creds.Password,
+		OktaAwsSAMLUrl: oktaAwsSAMLUrl,
+		CookieJar:      jar,
+		BaseURL:        base,
+		MFADevice:      mfaDevice,
+		Domain:         domain,
 	}, nil
 }
 
@@ -419,12 +419,12 @@ func (o *OktaClient) Get(method string, path string, data []byte, recv interface
 	var header http.Header
 	var client http.Client
 
- 	url, err := url.Parse(fmt.Sprintf(
- 		"%s/%s", o.BaseURL, path,
- 	))
- 	if err != nil {
- 		return err
- 	}
+	url, err := url.Parse(fmt.Sprintf(
+		"%s/%s", o.BaseURL, path,
+	))
+	if err != nil {
+		return err
+	}
 
 	if format == "json" {
 		header = http.Header{
@@ -483,6 +483,7 @@ type OktaProvider struct {
 	SessionDuration time.Duration
 	OktaAwsSAMLUrl  string
 	MFADevice       string
+	OktaSessionKey  string
 }
 
 func (p *OktaProvider) Retrieve() (sts.Credentials, string, error) {
@@ -500,7 +501,7 @@ func (p *OktaProvider) Retrieve() (sts.Credentials, string, error) {
 
 	// Check for stored session cookie
 	var sessionCookie string
-	cookieItem, err := p.Keyring.Get("okta-session-cookie")
+	cookieItem, err := p.Keyring.Get(p.OktaSessionKey)
 	if err == nil {
 		sessionCookie = string(cookieItem.Data)
 	}
@@ -516,7 +517,7 @@ func (p *OktaProvider) Retrieve() (sts.Credentials, string, error) {
 	}
 
 	newCookieItem := keyring.Item{
-		Key:   "okta-session-cookie",
+		Key:   p.OktaSessionKey,
 		Data:  []byte(newSessionCookie),
 		Label: "okta session cookie",
 		KeychainNotTrustApplication: false,


### PR DESCRIPTION
I have a specific case I want to solve here:

In addition to using aws-okta on the command line, I am using the aws-okta library for another Go application. This means that two separate applications need to access the same session stored in the keyring. The problem here is that on Mac OSX Keychain specifically, by default, items are only accessible by the application that created the Keychain.

To solve this problem, in this pull request, I am allowing the ability to configure the key to be stored in the keychain, so the separate applications can read from different items in the Keychain. Note: I haven't tested this on non-Keychain backends, and am not sure of the implications of different keys with identical labels (works fine in Keychain).

I also made some lint fixes, which I am happy to revert.