### PR TITLE
Rename Sirupsen to sirupsen

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/99designs/keyring"
 	analytics "github.com/segmentio/analytics-go"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,8 +6,8 @@ import (
 	"os"
 
 	"github.com/99designs/keyring"
-	log "github.com/Sirupsen/logrus"
 	analytics "github.com/segmentio/analytics-go"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,6 @@ module github.com/segmentio/aws-okta
 
 require (
 	github.com/99designs/keyring v0.0.0-20181012025958-ff690aee77e9
-	github.com/Sirupsen/logrus v0.0.0-20170515105910-5e5dc898656f
 	github.com/aulanov/go.dbus v0.0.0-20150729231527-25c3068a42a0
 	github.com/aws/aws-sdk-go v0.0.0-20170323003848-3bc643c63c6f
 	github.com/danieljoos/wincred v1.0.1
@@ -17,6 +16,7 @@ require (
 	github.com/mitchellh/go-homedir v0.0.0-20161203194507-b8bc1bf76747
 	github.com/segmentio/analytics-go v0.0.0-20180319165424-4f08212e9b32
 	github.com/segmentio/backo-go v0.0.0-20160424052352-204274ad699c
+	github.com/sirupsen/logrus v0.0.0-20170515105910-5e5dc898656f
 	github.com/skratchdot/open-golang v0.0.0-20160302144031-75fb7ed4208c
 	github.com/spf13/cobra v0.0.0-20170621173259-31694f19adee
 	github.com/spf13/pflag v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ github.com/99designs/keyring v0.0.0-20180523072454-ccd0779e6f10 h1:sQgghNA6oD/My
 github.com/99designs/keyring v0.0.0-20180523072454-ccd0779e6f10/go.mod h1:aKt8W/yd91/xHY6ixZAJZ2vYbhr3pP8DcrvuGSGNPJk=
 github.com/99designs/keyring v0.0.0-20181012025958-ff690aee77e9 h1:jst3zUpvYIaHu9OIWsR7w6z7a9sDfdWiXRak7URECV8=
 github.com/99designs/keyring v0.0.0-20181012025958-ff690aee77e9/go.mod h1:aKt8W/yd91/xHY6ixZAJZ2vYbhr3pP8DcrvuGSGNPJk=
-github.com/Sirupsen/logrus v0.0.0-20170515105910-5e5dc898656f h1:l5KPkrd6ZQ4mZnlWo4Eoll9mYPR98HXL6KcdShW4uTk=
-github.com/Sirupsen/logrus v0.0.0-20170515105910-5e5dc898656f/go.mod h1:rmk17hk6i8ZSAJkSDa7nOxamrG+SP4P0mm+DAvExv4U=
 github.com/aulanov/go.dbus v0.0.0-20150729231527-25c3068a42a0 h1:EEDvbomAQ+MFWqJ9FM6RXyJTkc4lckyWsbc5CGQkG1Y=
 github.com/aulanov/go.dbus v0.0.0-20150729231527-25c3068a42a0/go.mod h1:VHvUx+4lTCaJ8zUnEXF4cWEc9c8lnDt4PGLwlZ+3yaM=
 github.com/aws/aws-sdk-go v0.0.0-20170323003848-3bc643c63c6f h1:jUaGnP0b/8/iuYRSz0wldEkOmRa6Veb/bRy55KOdQwQ=
@@ -29,6 +27,8 @@ github.com/segmentio/analytics-go v0.0.0-20180319165424-4f08212e9b32 h1:tYR5qRFh
 github.com/segmentio/analytics-go v0.0.0-20180319165424-4f08212e9b32/go.mod h1:C7CYBtQWk4vRk2RyLu0qOcbHJ18E3F1HV2C/8JvKN48=
 github.com/segmentio/backo-go v0.0.0-20160424052352-204274ad699c h1:rsRTAcCR5CeNLkvgBVSjQoDGRRt6kggsE6XYBqCv2KQ=
 github.com/segmentio/backo-go v0.0.0-20160424052352-204274ad699c/go.mod h1:kJ9mm9YmoWSkk+oQ+5Cj8DEoRCX2JT6As4kEtIIOp1M=
+github.com/sirupsen/logrus v0.0.0-20170515105910-5e5dc898656f h1:l5KPkrd6ZQ4mZnlWo4Eoll9mYPR98HXL6KcdShW4uTk=
+github.com/sirupsen/logrus v0.0.0-20170515105910-5e5dc898656f/go.mod h1:rmk17hk6i8ZSAJkSDa7nOxamrG+SP4P0mm+DAvExv4U=
 github.com/skratchdot/open-golang v0.0.0-20160302144031-75fb7ed4208c h1:fyKiXKO1/I/B6Y2U8T7WdQGWzwehOuGIrljPtt7YTTI=
 github.com/skratchdot/open-golang v0.0.0-20160302144031-75fb7ed4208c/go.mod h1:sUM3LWHvSMaG192sy56D9F7CNvL7jUJVXoqM1QKLnog=
 github.com/spf13/cobra v0.0.0-20170621173259-31694f19adee h1:vZmAzioCtW2XsGeBJZECjqCx3NjSDqlia/fhPs+XXAg=

--- a/lib/config.go
+++ b/lib/config.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/mitchellh/go-homedir"
 	"github.com/vaughan0/go-ini"

--- a/lib/duo.go
+++ b/lib/duo.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"net/url"
 

--- a/lib/okta.go
+++ b/lib/okta.go
@@ -16,7 +16,7 @@ import (
 	"golang.org/x/net/publicsuffix"
 
 	"github.com/99designs/keyring"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts"

--- a/lib/okta.go
+++ b/lib/okta.go
@@ -16,11 +16,11 @@ import (
 	"golang.org/x/net/publicsuffix"
 
 	"github.com/99designs/keyring"
-	log "github.com/sirupsen/logrus"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/segmentio/aws-okta/lib/saml"
+	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/lib/provider.go
+++ b/lib/provider.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/99designs/keyring"
 	"github.com/aws/aws-sdk-go/aws"

--- a/lib/sessions.go
+++ b/lib/sessions.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/99designs/keyring"
 	"github.com/aws/aws-sdk-go/service/sts"

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -9,12 +9,6 @@
 			"revisionTime": "2018-05-23T07:24:54Z"
 		},
 		{
-			"checksumSHA1": "DYv6Q1+VfnUVxMwvk5IshAClLvw=",
-			"path": "github.com/Sirupsen/logrus",
-			"revision": "5e5dc898656f695e2a086b8e12559febbfc01562",
-			"revisionTime": "2017-05-15T10:45:16Z"
-		},
-		{
 			"checksumSHA1": "bD0oh9rHp+3ElrjWtaou004QTt8=",
 			"path": "github.com/aulanov/go.dbus",
 			"revision": "25c3068a42a0b50b877953fb249dbcffc6bd1bca",
@@ -293,6 +287,12 @@
 			"path": "github.com/segmentio/backo-go",
 			"revision": "204274ad699c0983a70203a566887f17a717fef4",
 			"revisionTime": "2016-04-24T05:23:52Z"
+		},
+		{
+			"checksumSHA1": "DYv6Q1+VfnUVxMwvk5IshAClLvw=",
+			"path": "github.com/sirupsen/logrus",
+			"revision": "5e5dc898656f695e2a086b8e12559febbfc01562",
+			"revisionTime": "2017-05-15T10:45:16Z"
 		},
 		{
 			"checksumSHA1": "h/HMhokbQHTdLUbruoBBTee+NYw=",


### PR DESCRIPTION
This may not be the expected usage of aws-okta, but I am using the lib component of aws-okta for another tool. The problem I am facing is that the existing tool imports sirupsen as lowercase, and therefore seems to be unable to vendor aws-okta properly.

I am not a Go expert, so I don't know if this is the right approach, but this seems to fix my problem. The guideline in [sirupsen's README](https://github.com/sirupsen/logrus) suggests that "Everything using logrus will need to use the lower-case: github.com/sirupsen/logrus".