### PR TITLE
Increase timeouts to allow auth over slow connections

### DIFF
--- a/lib/okta.go
+++ b/lib/okta.go
@@ -31,6 +31,8 @@ const (
 
 	// deprecated; use OktaServerUs
 	OktaServer = OktaServerUs
+
+	Timeout = time.Duration(60 * time.Second)
 )
 
 type OktaClient struct {
@@ -436,8 +438,13 @@ func (o *OktaClient) Get(method string, path string, data []byte, recv interface
 		header = http.Header{}
 	}
 
+	transCfg := &http.Transport{
+		TLSHandshakeTimeout: Timeout,
+	}
 	client = http.Client{
-		Jar: o.CookieJar,
+		Transport: transCfg,
+		Timeout:   Timeout,
+		Jar:       o.CookieJar,
 	}
 
 	req := &http.Request{


### PR DESCRIPTION
This is a pretty small change, but the issue always hamstrings me when I fly and I usually forget about it right after I land.

Currently either the TLS handshake (10s default) or subsequent connection can time out on a slow network - for example, airplane wi-fi. This makes those timeouts 60s apiece so those attempts have a better chance of getting through successfully.