### PR TITLE
aws-okta complains about missing a `aws_saml_url`

### DIFF
--- a/lib/okta.go
+++ b/lib/okta.go
@@ -101,7 +101,7 @@ func NewOktaClient(creds OktaCreds, oktaAwsSAMLUrl string, sessionCookie string,
 	} else if creds.Domain != "" {
 		domain = creds.Domain
 	} else {
-		return &OktaClient{}, errors.New("either creds.Organization (deprecated) or creds.Domain must be set, and not both")
+		return &OktaClient{}, errors.New("either creds.Organization (deprecated) or creds.Domain must be set, but not both. To remedy this, re-add your credentials with `aws-okta add`")
 	}
 
 	// url parse & set base
@@ -526,9 +526,9 @@ func (p *OktaProvider) Retrieve() (sts.Credentials, string, error) {
 	}
 
 	newCookieItem := keyring.Item{
-		Key:   p.OktaSessionCookieKey,
-		Data:  []byte(newSessionCookie),
-		Label: "okta session cookie",
+		Key:                         p.OktaSessionCookieKey,
+		Data:                        []byte(newSessionCookie),
+		Label:                       "okta session cookie",
 		KeychainNotTrustApplication: false,
 	}
 

--- a/lib/provider.go
+++ b/lib/provider.go
@@ -137,19 +137,19 @@ func (p *Provider) Retrieve() (credentials.Value, error) {
 func (p *Provider) getSamlURL() (string, error) {
 	oktaAwsSAMLUrl, profile, err := p.profiles.GetValue(p.profile, "aws_saml_url")
 	if err != nil {
-		log.Debugf("Using aws_saml_url from profile: %s", profile)
-		return oktaAwsSAMLUrl, nil
+		return "", errors.New("aws_saml_url missing from ~/.aws/config")
 	}
-	return "", errors.New("aws_saml_url missing from ~/.aws/config")
+	log.Debugf("Using aws_saml_url from profile: %s", profile)
+	return oktaAwsSAMLUrl, nil
 }
 
 func (p *Provider) getOktaSessionCookieKey() string {
 	oktaSessionCookieKey, profile, err := p.profiles.GetValue(p.profile, "okta_session_cookie_key")
 	if err != nil {
-		log.Debugf("Using okta_session_cookie_key from profile: %s", profile)
-		return oktaSessionCookieKey
+		return "okta-session-cookie"
 	}
-	return "okta-session-cookie"
+	log.Debugf("Using okta_session_cookie_key from profile: %s", profile)
+	return oktaSessionCookieKey
 }
 
 func (p *Provider) getSamlSessionCreds() (sts.Credentials, error) {


### PR DESCRIPTION
This fixes the bug in master where `aws-okta` complains about a missing `aws_saml_url`

```
$ aws-okta login staging
aws_saml_url missing from ~/.aws/config
```

We've mixed up the error handling inside `provider.go`

+ Also added more steps to fix the bad credentials error message