### PR TITLE
Log in via the saml URL if the profile contains one

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -64,7 +64,8 @@ func loginRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if _, ok := profiles[profile]; !ok {
+	prof, ok := profiles[profile]
+	if !ok {
 		return fmt.Errorf("Profile '%s' not found in your aws config", profile)
 	}
 
@@ -108,6 +109,31 @@ func loginRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if _, ok := prof["aws_saml_url"]; ok {
+		oktaLogin(p)
+	} else {
+		federatedLogin(p, profile, profiles)
+	}
+
+	return nil
+}
+
+func oktaLogin(p *lib.Provider) error {
+	loginURL, err := p.GetSamlLoginURL()
+	if err != nil {
+		return err
+	}
+
+	if Stdout {
+		fmt.Println(loginURL.String())
+	} else if err := open.Run(loginURL.String()); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func federatedLogin(p *lib.Provider, profile string, profiles lib.Profiles) error {
 	creds, err := p.Retrieve()
 	if err != nil {
 		return err

--- a/lib/okta.go
+++ b/lib/okta.go
@@ -536,3 +536,39 @@ func (p *OktaProvider) Retrieve() (sts.Credentials, string, error) {
 
 	return creds, oktaCreds.Username, err
 }
+
+func (p *OktaProvider) GetSamlLoginURL() (*url.URL, error) {
+	item, err := p.Keyring.Get("okta-creds")
+	if err != nil {
+		log.Debugf("couldnt get okta creds from keyring: %s", err)
+		return &url.URL{}, err
+	}
+
+	var oktaCreds OktaCreds
+	if err = json.Unmarshal(item.Data, &oktaCreds); err != nil {
+		return &url.URL{}, errors.New("Failed to get okta credentials from your keyring.  Please make sure you have added okta credentials with `aws-okta add`")
+	}
+
+	var samlURL string
+
+	// maintain compatibility for deprecated creds.Organization
+	if oktaCreds.Domain == "" && oktaCreds.Organization != "" {
+		samlURL = fmt.Sprintf("%s.%s", oktaCreds.Organization, OktaServerDefault)
+	} else if oktaCreds.Domain != "" {
+		samlURL = oktaCreds.Domain
+	} else {
+		return &url.URL{}, errors.New("either oktaCreds.Organization (deprecated) or oktaCreds.Domain must be set, but not both. To remedy this, re-add your credentials with `aws-okta add`")
+	}
+
+	fullSamlURL, err := url.Parse(fmt.Sprintf(
+		"https://%s/%s",
+		samlURL,
+		p.OktaAwsSAMLUrl,
+	))
+
+	if err != nil {
+		return &url.URL{}, err
+	}
+
+	return fullSamlURL, nil
+}


### PR DESCRIPTION
This PR changes the `login` command to prioritize the `aws_saml_url` for the target profile if it contains one. If not, it falls back to using the federated login API.

Using the federated login method is problematic if your config has multiple accounts. Any time you login to another role on a **different** account, you're greeted with a page saying you must sign out first.