### PR TITLE
Add Proxy support for OktaClient.Get

### DIFF
--- a/lib/okta.go
+++ b/lib/okta.go
@@ -439,6 +439,7 @@ func (o *OktaClient) Get(method string, path string, data []byte, recv interface
 	}
 
 	transCfg := &http.Transport{
+		Proxy:               http.ProxyFromEnvironment,
 		TLSHandshakeTimeout: Timeout,
 	}
 	client = http.Client{


### PR DESCRIPTION
Adds the default behavior of pulling proxy information from environment variables.