### PR TITLE
Add cmd flags

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -12,6 +12,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	organization string
+	oktaRegion   string
+	oktaDomain   string
+)
+
 // addCmd represents the add command
 var addCmd = &cobra.Command{
 	Use:   "add",
@@ -21,6 +27,10 @@ var addCmd = &cobra.Command{
 
 func init() {
 	RootCmd.AddCommand(addCmd)
+	addCmd.Flags().StringVarP(&organization, "organization", "o", "", "Okta organization")
+	addCmd.Flags().StringVarP(&oktaRegion, "region", "r", "", "Okta region")
+	addCmd.Flags().StringVarP(&oktaDomain, "domain", "a", "", "Okta domain address")
+	addCmd.Flags().StringVarP(&username, "username", "u", "", "Okta username")
 }
 
 func add(cmd *cobra.Command, args []string) error {
@@ -46,27 +56,37 @@ func add(cmd *cobra.Command, args []string) error {
 	}
 
 	// Ask username password from prompt
-	organization, err := lib.Prompt("Okta organization", false)
-	if err != nil {
-		return err
+	if organization == "" {
+		organization, err = lib.Prompt("Okta organization", false)
+		if err != nil {
+			return err
+		}
+
 	}
 
-	oktaRegion, err := lib.Prompt("Okta region ([us], emea, preview)", false)
-	if err != nil {
-		return err
-	}
 	if oktaRegion == "" {
-		oktaRegion = "us"
+		oktaRegion, err = lib.Prompt("Okta region ([us], emea, preview)", false)
+		if err != nil {
+			return err
+		}
+		if oktaRegion == "" {
+			oktaRegion = "us"
+		}
+
 	}
 
-	oktaDomain, err := lib.Prompt("Okta domain ["+oktaRegion+".okta.com]", false)
-	if err != nil {
-		return err
+	if oktaDomain == "" {
+		oktaDomain, err = lib.Prompt("Okta domain ["+oktaRegion+".okta.com]", false)
+		if err != nil {
+			return err
+		}
 	}
 
-	username, err := lib.Prompt("Okta username", false)
-	if err != nil {
-		return err
+	if username == "" {
+		username, err = lib.Prompt("Okta username", false)
+		if err != nil {
+			return err
+		}
 	}
 
 	password, err := lib.Prompt("Okta password", true)
@@ -98,9 +118,9 @@ func add(cmd *cobra.Command, args []string) error {
 	}
 
 	item := keyring.Item{
-		Key:   "okta-creds",
-		Data:  encoded,
-		Label: "okta credentials",
+		Key:                         "okta-creds",
+		Data:                        encoded,
+		Label:                       "okta credentials",
 		KeychainNotTrustApplication: false,
 	}
 

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -44,6 +44,11 @@ func add(cmd *cobra.Command, args []string) error {
 		log.Fatal(err)
 	}
 
+	if _, err := kr.Get("okta-creds"); err == nil {
+		log.Infof("Credentials already added.")
+		return nil
+	}
+
 	if analyticsEnabled && analyticsClient != nil {
 		analyticsClient.Enqueue(analytics.Track{
 			UserId: username,


### PR DESCRIPTION
Firstly, I wanted to express how grateful we are for this tool. It's going to drastically change the way we do access management for the better across our engineering org. I was wondering if you think the following change is acceptable?

The first commit adds optional flags for the add command in lieu of asking for user input. We want to be able to roll this out for all engineers with an on-boarding process that's as seamless as possible. The flags will help us automate the things we already know about and only prompt for the things we don't.

The second commit is attempting to make the add command idempotent for the "okta-creds" key on a given backend. This makes it easy to run the add command every time and not get an error if the user already has their credentials populated in their keychain.

Happy to discuss our goals further and open to other ideas in accomplishing the same.