### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-from golang as build
+from golang:1.11 as build
 
 ENV SRC github.com/segmentio/aws-okta
 ARG VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+from golang as build
+
+ENV SRC github.com/segmentio/aws-okta
+ARG VERSION
+
+WORKDIR /build
+COPY . /go/src/${SRC}
+
+RUN apt-get update
+RUN apt-get install --no-install-recommends -y \
+    libusb-1.0-0-dev \
+    ca-certificates \
+    build-essential \
+    git
+
+RUN CGO_ENABLED=1 go build -o aws-okta -ldflags="-X main.version=$VERSION" ${SRC}/cmd
+
+FROM scratch
+COPY --from=build /build/aws-okta /
+ENTRYPOINT ["/aws-okta"]
+

--- a/README.md
+++ b/README.md
@@ -162,6 +162,14 @@ For Linux / Ubuntu add the following to your bash config / zshrc etc:
 export AWS_OKTA_BACKEND=secret-service
 ```
 
+## Local Development
+
+If you're developing in Linux, you'll need to get `libusb`. For Ubuntu, install the libusb-1.0-0-dev or use the `Dockerfile` provided in the repo.
+
+## Running Tests
+
+`make test`
+
 ## Releasing
 
 Pushing a new tag will cause Circle to automatically create and push a linux release.  After this is done, you should run (from a mac):


### PR DESCRIPTION
This relates to a question brought up in #109. I went ahead and added a Dockerfile for executing the build in Ubuntu as a demonstration of this need for a dependency.

Should we add a  `docker build ...` to our tests to ensure that we're building against this? 