### PR TITLE
WIP Add TLS key log to okta and duo libs, use in `add`

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -92,11 +92,10 @@ func add(cmd *cobra.Command, args []string) error {
 		return ErrFailedToValidateCredentials
 	}
 	keyLogFile := addTLSKeyLog(oktaClient)
-	defer func() {
-		if keyLogFile != nil {
-			keyLogFile.Close()
-		}
-	}()
+
+	if keyLogFile != nil {
+		defer keyLogFile.Close()
+	}
 
 	if err := creds.ValidateWithClient(oktaClient); err != nil {
 		log.Debugf("Failed to validate credentials: %s", err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,7 +23,7 @@ var (
 )
 
 // if non-zero, will log TLS keys to this file
-var UseTLSKeyLogFile = "yes"
+var UseTLSKeyLogFile = ""
 
 // SSL to be consistent with other producers, like Firefox and Chrome
 const TLSKeyLogFileEnv = "SSLKEYLOGFILE"


### PR DESCRIPTION
This is a POC to show how TLS key logging might look, addressing #129. TLS key logging works by logging TLS session keys to a log file, which can then be used to decrypt a packet capture, even in the face of perfect forward secrecy.

- User must build with special flag: `go build -ldflags='-X cmd.UseTLSKeyLogFile=yes'`; this would be disabled in general release
- Start Wireshark packet capture
- Run `SSLKEYLOGFILE=./keylog aws-okta add`
- [Configure Wireshark to use key log](https://security.stackexchange.com/questions/35639/decrypting-tls-in-wireshark-when-using-dhe-rsa-ciphersuites/42350#42350)
- Use the filter `ssl && http` to see decrypted SSL.

I believe this would be fairly straightforward way for advanced users to be able to debug their raw HTTP traffic.

Alternatives:

# Setting up a MITM with omni-CA a la [Charles](https://www.charlesproxy.com/documentation/using-charles/ssl-certificates/)

MITM's all traffic and requires installing a root CA. Not very :lock:

# Dump all HTTP traffic to a file instead

- Probably more complicated in the code
- What dump format?