### PR TITLE
fix: ensure that DoStatus is called for u2f devices

### DIFF
--- a/lib/duo.go
+++ b/lib/duo.go
@@ -207,7 +207,7 @@ func (d *DuoClient) ChallengeU2f(verificationHost string) (err error) {
 	// immediately if successful, because it's a single check
 	// but for Push you get empty value and have to
 	// wait on second response post-push
-	if d.Device != "u2f" && d.Device != "token" {
+	if d.Device != "token" {
 		// This one should block untile 2fa completed
 		auth, _, err = d.DoStatus(txid, sid)
 		if err != nil {
@@ -349,7 +349,7 @@ func (d *DuoClient) DoU2FPromptFinish(sid string, sessionID string, resp *u2fhos
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
-		err = fmt.Errorf("Prompt request failed: %d", res.StatusCode)
+		err = fmt.Errorf("U2F Prompt request failed: %d", res.StatusCode)
 		return
 	}
 


### PR DESCRIPTION
Ran into #121 while trying to get setup with Duo + U2F. After comparing the flow in the code to the browser it looks like aws-okta isn't calling the Duo status endpoint properly. That is required to exchange the txid we get for something Okta will take.

I've tested this code with both U2F and Tokens and both now work.