### PR TITLE
Added CLI arguments for aws-okta add

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -83,10 +83,6 @@ func add(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Set calculated Okta domain if left blank
-	if oktaDomain == "" {
-	}
-
 	if username == "" {
 		username, err = lib.Prompt("Okta username", false)
 		if err != nil {

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -12,6 +12,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	organization string
+	oktaRegion   string
+	oktaDomain   string
+)
+
 // addCmd represents the add command
 var addCmd = &cobra.Command{
 	Use:   "add",
@@ -21,6 +27,10 @@ var addCmd = &cobra.Command{
 
 func init() {
 	RootCmd.AddCommand(addCmd)
+	addCmd.Flags().StringVarP(&organization, "organization", "", "", "Okta organization name")
+	addCmd.Flags().StringVarP(&oktaRegion, "okta-region", "", "", "Okta region (us, emea, preview)")
+	addCmd.Flags().StringVarP(&oktaDomain, "okta-domain", "", "", "Okta domain (e.g. <orgname>.okta.com)")
+	addCmd.Flags().StringVarP(&username, "okta-username", "", "", "Okta username")
 }
 
 func add(cmd *cobra.Command, args []string) error {
@@ -45,30 +55,39 @@ func add(cmd *cobra.Command, args []string) error {
 		})
 	}
 
-	// Ask username password from prompt
-	organization, err := lib.Prompt("Okta organization", false)
-	if err != nil {
-		return err
+	// Ask Okta organization details and username if not given in command line arguments
+	if organization == "" {
+		organization, err = lib.Prompt("Okta organization", false)
+		if err != nil {
+			return err
+		}
 	}
 
-	oktaRegion, err := lib.Prompt("Okta region ([us], emea, preview)", false)
-	if err != nil {
-		return err
+	if oktaRegion == "" {
+		oktaRegion, err = lib.Prompt("Okta region ([us], emea, preview)", false)
+		if err != nil {
+			return err
+		}
 	}
 	if oktaRegion == "" {
 		oktaRegion = "us"
 	}
 
-	oktaDomain, err := lib.Prompt("Okta domain ["+oktaRegion+".okta.com]", false)
-	if err != nil {
-		return err
+	if oktaDomain == "" {
+		oktaDomain, err = lib.Prompt("Okta domain ["+organization+".okta.com]", false)
+		if err != nil {
+			return err
+		}
 	}
 
-	username, err := lib.Prompt("Okta username", false)
-	if err != nil {
-		return err
+	if username == "" {
+		username, err = lib.Prompt("Okta username", false)
+		if err != nil {
+			return err
+		}
 	}
 
+	// Ask for password from prompt
 	password, err := lib.Prompt("Okta password", true)
 	if err != nil {
 		return err
@@ -98,9 +117,9 @@ func add(cmd *cobra.Command, args []string) error {
 	}
 
 	item := keyring.Item{
-		Key:   "okta-creds",
-		Data:  encoded,
-		Label: "okta credentials",
+		Key:                         "okta-creds",
+		Data:                        encoded,
+		Label:                       "okta credentials",
 		KeychainNotTrustApplication: false,
 	}
 

--- a/lib/okta.go
+++ b/lib/okta.go
@@ -86,7 +86,7 @@ func (c *OktaCreds) Validate(mfaConfig MFAConfig) error {
 	return nil
 }
 
-func getOktaDomain(region string) (string, error) {
+func GetOktaDomain(region string) (string, error) {
 	switch region {
 	case "us":
 		return OktaServerUs, nil

--- a/lib/okta.go
+++ b/lib/okta.go
@@ -131,6 +131,7 @@ func NewOktaClient(creds OktaCreds, oktaAwsSAMLUrl string, sessionCookie string,
 			},
 		})
 	}
+	log.Debug("domain: " + domain)
 
 	return &OktaClient{
 		// Setting Organization for backwards compatibility
@@ -561,9 +562,9 @@ func (p *OktaProvider) Retrieve() (sts.Credentials, string, error) {
 	}
 
 	newCookieItem := keyring.Item{
-		Key:   p.OktaSessionCookieKey,
-		Data:  []byte(newSessionCookie),
-		Label: "okta session cookie",
+		Key:                         p.OktaSessionCookieKey,
+		Data:                        []byte(newSessionCookie),
+		Label:                       "okta session cookie",
 		KeychainNotTrustApplication: false,
 	}
 


### PR DESCRIPTION
- Added CLI arguments for Okta organization (deprecated?), Okta region, Okta domain and Okta username. Reason: We would rather give our employees a single simple command to run already configured with our company's variables, rather than tell them "when you see this prompt, type this"
- Updated oktaDomain example value to `["+organization+".okta.com]` because after reading the code it seems like this is actually the format that is derived, not `"+region+".okta.com`.
- Included a log line for the oktaDomain to verify this
- Indentation fixes