### PR TITLE
Avoid clobbering the  --username flag when running add subcommand

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -83,9 +83,9 @@ func prerun(cmd *cobra.Command, args []string) {
 			BatchSize: 1,
 		})
 
-		username = os.Getenv("USER")
+		usr := os.Getenv("USER")
 		analyticsClient.Enqueue(analytics.Identify{
-			UserId: username,
+			UserId: usr,
 			Traits: analytics.NewTraits().
 				Set("aws-okta-version", version),
 		})


### PR DESCRIPTION
Bug is illustrated here:
```
LDmbp: ~ $ aws-okta add --domain segment.okta.com --username leif@segment.com -d
Okta password: 

DEBU[0005] domain: segment.okta.com                     
DEBU[0005] Step: 1                                      
DEBU[0005] Failed to validate credentials: Failed to authenticate with okta: &errors.errorString{s:"POST https://segment.okta.com/api/v1/authn: 401 Unauthorized"} 
Failed to validate credentials
LDmbp: ~ $ bash okta.sh 
Which team are you on?
Options are: app, biztech, foundation, personas, platform, product, success
Enter the team based on the table in the setup doc:
foundation
Pulling down /Users/leifdreizler/.aws/config
✔️: Your old aws config has been backed up in /tmp/awsconfig-358d044b5eb575f6b9e5623a20ab5535
✔️: Your aws config was successfully updated.

Respond to the prompts to configure aws-okta
Organization should be "segment"
Region and domain should use the default (us) regardless of whether or not you work in emea
You will need your phone to accept a 2 factor auth push notification
EXAMPLE:
Okta organization: segment
Okta region ([us], emea, preview):
Okta domain [us.okta.com]:
Okta username: john.boggs@segment.com

Okta organization: segment

Okta region ([us], emea, preview): 

Okta domain [segment.okta.com]: 

Okta password: 

Failed to validate credentials
LDmbp: ~ $ ```