### PR TITLE
fix: idempotent publishes

### DIFF
--- a/Makefile.release
+++ b/Makefile.release
@@ -5,11 +5,17 @@
 
 include Makefile
 
+# use bash so we can use set -o pipefail
+SHELL := /bin/bash
+
 # set --pre-release if not tagged or tree is dirty or there's a `-` in the tag
 ifneq (,$(findstring -,$(VERSION)))
 	GITHUB_RELEASE_FLAGS := "--pre-release"
 	PACKAGECLOUD_NAME_SUFFIX := "-prerelease"
 endif
+
+# TODO: use this consistently; 99% of the time, we don't want a v
+VERSION_NO_V := $(patsubst v%,%,$(VERSION))
 
 PACKAGECLOUD_DEB_DISTROS := \
 	debian/stretch \
@@ -41,7 +47,12 @@ github-release:
 	--repo aws-okta \
 	$(GITHUB_RELEASE_FLAGS) \
 	--tag $(VERSION) \
-	--name $(VERSION)
+	--name $(VERSION) || \
+	github-release info \
+	--security-token $$GH_LOGIN \
+	--user segmentio \
+	--repo aws-okta \
+	--tag $(VERSION)
 
 publish-github-darwin-bin: dist/aws-okta-$(VERSION)-darwin-amd64 | github-release
 	github-release upload \
@@ -50,6 +61,7 @@ publish-github-darwin-bin: dist/aws-okta-$(VERSION)-darwin-amd64 | github-releas
 	--repo aws-okta \
 	--tag $(VERSION) \
 	--name aws-okta-$(VERSION)-darwin-amd64 \
+	--replace \
 	--file $<
 
 publish-github-linux-bin: dist/aws-okta-$(VERSION)-linux-amd64 | github-release
@@ -59,6 +71,7 @@ publish-github-linux-bin: dist/aws-okta-$(VERSION)-linux-amd64 | github-release
 	--repo aws-okta \
 	--tag $(VERSION) \
 	--name aws-okta-$(VERSION)-linux-amd64 \
+	--replace \
 	--file $<
 
 publish-github-deb: dist/aws-okta_$(VERSION)_amd64.deb | github-release
@@ -68,6 +81,7 @@ publish-github-deb: dist/aws-okta_$(VERSION)_amd64.deb | github-release
 	--repo aws-okta \
 	--tag $(VERSION) \
 	--name aws-okta_$(VERSION)_amd64.deb \
+	--replace \
 	--file $<
 
 publish-github-rpm: dist/aws-okta_$(VERSION)_amd64.rpm | github-release
@@ -77,6 +91,7 @@ publish-github-rpm: dist/aws-okta_$(VERSION)_amd64.rpm | github-release
 	--repo aws-okta \
 	--tag $(VERSION) \
 	--name aws-okta_$(VERSION)_amd64.rpm \
+	--replace \
 	--file $<
 	
 publish-github-sha256sums: dist/aws-okta-$(VERSION).sha256sums | github-release
@@ -86,6 +101,7 @@ publish-github-sha256sums: dist/aws-okta-$(VERSION).sha256sums | github-release
 	--repo aws-okta \
 	--tag $(VERSION) \
 	--name aws-okta-$(VERSION).sha256sums \
+	--replace \
 	--file dist/aws-okta-$(VERSION).sha256sums
 
 packagecloud.conf.json:
@@ -95,13 +111,19 @@ packagecloud.conf.json:
 # so we attempt to filter that out
 
 publish-packagecloud-deb: dist/aws-okta_$(VERSION)_amd64.deb packagecloud.conf.json
-	@for v in $(PACKAGECLOUD_DEB_DISTROS); do \
+	@set -o pipefail; \
+	for v in $(PACKAGECLOUD_DEB_DISTROS); do \
+		(package_cloud yank --config packagecloud.conf.json segment/aws-okta$(PACKAGECLOUD_NAME_SUFFIX)/$$v aws-okta_$(VERSION_NO_V)_amd64.deb || true) | \
+			grep -v 'with token:' || true ; \
 		package_cloud push --config packagecloud.conf.json segment/aws-okta$(PACKAGECLOUD_NAME_SUFFIX)/$$v $< | \
 			grep -v 'with token:' ; \
 	done
 
 publish-packagecloud-rpm: dist/aws-okta_$(VERSION)_amd64.rpm packagecloud.conf.json
-	@for v in $(PACKAGECLOUD_RPM_DISTROS); do \
+	@set -o pipefail; \
+	for v in $(PACKAGECLOUD_RPM_DISTROS); do \
+		(package_cloud yank --config packagecloud.conf.json segment/aws-okta$(PACKAGECLOUD_NAME_SUFFIX)/$$v aws-okta-$(subst -,_,$(VERSION_NO_V))-1.x86_64.rpm || true) | \
+			grep -v 'with token:' || true ; \
 		package_cloud push --config packagecloud.conf.json segment/aws-okta$(PACKAGECLOUD_NAME_SUFFIX)/$$v $< | \
 			grep -v 'with token:' ; \
 	done

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -289,7 +289,7 @@
 			"revisionTime": "2016-04-24T05:23:52Z"
 		},
 		{
-			"checksumSHA1": "DYv6Q1+VfnUVxMwvk5IshAClLvw=",
+			"checksumSHA1": "x/C9sWJ33glBGKgGvb8VvUQvR8s=",
 			"path": "github.com/sirupsen/logrus",
 			"revision": "5e5dc898656f695e2a086b8e12559febbfc01562",
 			"revisionTime": "2017-05-15T10:45:16Z"


### PR DESCRIPTION
So we can rebuild in the face of temporary failure. 

For example, this publish failed https://circleci.com/gh/segmentio/aws-okta/452, then this attempt to rerun failed https://circleci.com/gh/segmentio/aws-okta/454

Using this branch and a prerelease tag:
- [initial run](https://circleci.com/workflow-run/84c493b1-e4f8-4128-989e-a714e00fb5b7)
- [rebuild](https://circleci.com/workflow-run/78ecb644-9c7e-4aac-9a84-2123d0b1fb1b)