### PR TITLE
Don't swallow errors from login operations

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -112,12 +112,9 @@ func loginRun(cmd *cobra.Command, args []string) error {
 	}
 
 	if _, ok := prof["aws_saml_url"]; ok {
-		oktaLogin(p)
-	} else {
-		federatedLogin(p, profile, profiles)
+		return oktaLogin(p)
 	}
-
-	return nil
+	return federatedLogin(p, profile, profiles)
 }
 
 func oktaLogin(p *lib.Provider) error {


### PR DESCRIPTION
We were troubleshooting some issues with `aws-okta login ...` and discovered that the error, in this case, was being swallowed. This happens if you try to run `aws-okta login ...` before doing `aws-okta add`. 