### PR TITLE
Disabled transport encoding to okta to prevent EOF

### DIFF
--- a/lib/okta.go
+++ b/lib/okta.go
@@ -476,6 +476,8 @@ func (o *OktaClient) Get(method string, path string, data []byte, recv interface
 			"Cache-Control": []string{"no-cache"},
 		}
 	} else {
+		// disable gzip encoding; it was causing spurious EOFs
+		// for some users; see #148
 		header = http.Header{
 			"Accept-Encoding": []string{"identity"},
 		}

--- a/lib/okta.go
+++ b/lib/okta.go
@@ -476,7 +476,9 @@ func (o *OktaClient) Get(method string, path string, data []byte, recv interface
 			"Cache-Control": []string{"no-cache"},
 		}
 	} else {
-		header = http.Header{}
+		header = http.Header{
+			"Accept-Encoding": []string{"identity"},
+		}
 	}
 
 	transCfg := &http.Transport{


### PR DESCRIPTION
Our users would get constant "unexpected EOF" errors when trying to authenticate with 2FA against okta.

We traced the cause to trying to decode the transport encoding (gzip) on the chunked body stream in the response.  

This causes `ReadAll` to return an `io.EOF` err even when it should not: https://github.com/segmentio/aws-okta/blob/b1140c3a208d3181325baf9bffe29cbc75ad58d5/lib/okta.go#L516

The fix that has worked is to add a header to prevent okta from encoding the response.