### PR TITLE
feat: Add `env` command that prints a sourceable configuration to STDOUT.

### DIFF
--- a/cmd/env.go
+++ b/cmd/env.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/99designs/keyring"
+	"github.com/alessio/shellescape"
 	analytics "github.com/segmentio/analytics-go"
 	"github.com/segmentio/aws-okta/lib"
 	"github.com/spf13/cobra"
@@ -94,18 +95,18 @@ func envRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fmt.Printf("export AWS_ACCESS_KEY_ID=%q\n", creds.AccessKeyID)
-	fmt.Printf("export AWS_SECRET_ACCESS_KEY=%q\n", creds.SecretAccessKey)
-	fmt.Printf("export AWS_OKTA_PROFILE=%q\n", profile)
+	fmt.Printf("export AWS_ACCESS_KEY_ID=%s\n", shellescape.Quote(creds.AccessKeyID))
+	fmt.Printf("export AWS_SECRET_ACCESS_KEY=%s\n", shellescape.Quote(creds.SecretAccessKey))
+	fmt.Printf("export AWS_OKTA_PROFILE=%s\n", shellescape.Quote(profile))
 
 	if region, ok := profiles[profile]["region"]; ok {
-		fmt.Printf("export AWS_DEFAULT_REGION=%q\n", region)
-		fmt.Printf("export AWS_REGION=%q\n", region)
+		fmt.Printf("export AWS_DEFAULT_REGION=%s\n", shellescape.Quote(region))
+		fmt.Printf("export AWS_REGION=%s\n", shellescape.Quote(region))
 	}
 
 	if creds.SessionToken != "" {
-		fmt.Printf("export AWS_SESSION_TOKEN=%q\n", creds.SessionToken)
-		fmt.Printf("export AWS_SECURITY_TOKEN=%q\n", creds.SessionToken)
+		fmt.Printf("export AWS_SESSION_TOKEN=%s\n", shellescape.Quote(creds.SessionToken))
+		fmt.Printf("export AWS_SECURITY_TOKEN=%s\n", shellescape.Quote(creds.SessionToken))
 	}
 
 	return nil

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -1,0 +1,112 @@
+package cmd
+
+import (
+	"fmt"
+
+	"os"
+	"time"
+
+	"github.com/99designs/keyring"
+	analytics "github.com/segmentio/analytics-go"
+	"github.com/segmentio/aws-okta/lib"
+	"github.com/spf13/cobra"
+)
+
+// shellCmd represents the shell command
+var shellCmd = &cobra.Command{
+	Use:       "shell <profile>",
+	Short:     "shell writes a sourceable export statements to set environment variables for the current shell for the specified profile",
+	RunE:      shellRun,
+	Example:   "source <$(aws-okta shell test)",
+	ValidArgs: listProfileNames(mustListProfiles()),
+}
+
+func init() {
+	RootCmd.AddCommand(shellCmd)
+	shellCmd.Flags().DurationVarP(&sessionTTL, "session-ttl", "t", time.Hour, "Expiration time for okta role session")
+	shellCmd.Flags().DurationVarP(&assumeRoleTTL, "assume-role-ttl", "a", time.Hour, "Expiration time for assumed role")
+}
+
+func shellRun(cmd *cobra.Command, args []string) error {
+	if len(args) < 1 {
+		return ErrTooFewArguments
+	}
+
+	profile := args[0]
+	config, err := lib.NewConfigFromEnv()
+	if err != nil {
+		return err
+	}
+
+	profiles, err := config.Parse()
+	if err != nil {
+		return err
+	}
+
+	if _, ok := profiles[profile]; !ok {
+		return fmt.Errorf("Profile '%s' not found in your aws config. Use list command to see configured profiles", profile)
+	}
+
+	updateMfaConfig(cmd, profiles, profile, &mfaConfig)
+
+	// check for an assume_role_ttl in the profile if we don't have a more explicit one
+	if !cmd.Flags().Lookup("assume-role-ttl").Changed {
+		if err := updateDurationFromConfigProfile(profiles, profile, &assumeRoleTTL); err != nil {
+			fmt.Fprintln(os.Stderr, "warning: could not parse duration from profile config")
+		}
+	}
+
+	opts := lib.ProviderOptions{
+		MFAConfig:          mfaConfig,
+		Profiles:           profiles,
+		SessionDuration:    sessionTTL,
+		AssumeRoleDuration: assumeRoleTTL,
+	}
+
+	var allowedBackends []keyring.BackendType
+	if backend != "" {
+		allowedBackends = append(allowedBackends, keyring.BackendType(backend))
+	}
+
+	kr, err := lib.OpenKeyring(allowedBackends)
+	if err != nil {
+		return err
+	}
+
+	if analyticsEnabled && analyticsClient != nil {
+		analyticsClient.Enqueue(analytics.Track{
+			UserId: username,
+			Event:  "Ran Command",
+			Properties: analytics.NewProperties().
+				Set("backend", backend).
+				Set("aws-okta-version", version).
+				Set("profile", profile).
+				Set("command", "shell"),
+		})
+	}
+
+	p, err := lib.NewProvider(kr, profile, opts)
+	if err != nil {
+		return err
+	}
+
+	creds, err := p.Retrieve()
+	if err != nil {
+		return err
+	}
+	fmt.Printf("export AWS_ACCESS_KEY_ID=%s\n", creds.AccessKeyID)
+	fmt.Printf("export AWS_SECRET_ACCESS_KEY=%s\n", creds.SecretAccessKey)
+	fmt.Printf("export AWS_OKTA_PROFILE=%s\n", profile)
+
+	if region, ok := profiles[profile]["region"]; ok {
+		fmt.Printf("export AWS_DEFAULT_REGION=%s\n", region)
+		fmt.Printf("export AWS_REGION=%s\n", region)
+		os.Setenv("AWS_REGION", region)
+	}
+	if creds.SessionToken != "" {
+		fmt.Printf("export AWS_SESSION_TOKEN=%s\n", creds.SessionToken)
+		fmt.Printf("export AWS_SECURITY_TOKEN=%s\n", creds.SessionToken)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This PR adds a new command, `aws-okta shell` which prints to stdout sourceable commands that set environment variables to the relevant aws profile.

The output looks like this:

```bash
./aws-okta shell test
```
```bash
export AWS_ACCESS_KEY_ID=FOO
export AWS_SECRET_ACCESS_KEY=BAR
export AWS_OKTA_PROFILE=test
export AWS_DEFAULT_REGION=us-east-1
export AWS_REGION=us-east-1
export AWS_SESSION_TOKEN=[LONG TOKEN]
export AWS_SECURITY_TOKEN=[LONG TOKEN]
```

and I use it like this:

```bash
source <(aws-okta shell test)
```
The inspiration for this was to provide an in-tool command to easily switch between AWS profiles, so that a user can use the aws-cli without have to run it through the `aws-okta exec` command.  I'm switching accounts multiple times a day, and it's useful to just have the appropriate credentials in my environment for a period of time.  Currently, this is being solved several different ways at my current company:

1. Myself and others have an executable that is a wrapper for `aws-okta exec [PROFILE] -- /bin/zsh`.  The downside to this is I have to fork a new shell, pay the startup cost for the new shell, and have a bunch of subshells running.

1. Anther colleague has a script that he runs once a day that takes each profile, grabs credentials and dumps them to his `~/.aws/credentials` file.

1. Another solution is an alias to a bash function:

```bash
_okta_aws () {
	aws-okta exec [PROFILE] -- aws "$@"
}
```

I'd imagine other people have other solutions.  While there is nothing wrong with the above solutions (or any other solution for that matter)! I thought it would be nice to centralize it in the tool.