### PR TITLE
feat: increase MaxSessionDuration to 90 days

### DIFF
--- a/lib/provider.go
+++ b/lib/provider.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	MaxSessionDuration    = time.Hour * 36
+	MaxSessionDuration    = time.Hour * 2160
 	MinSessionDuration    = time.Minute * 15
 	MinAssumeRoleDuration = time.Minute * 15
 	MaxAssumeRoleDuration = time.Hour * 12

--- a/lib/provider.go
+++ b/lib/provider.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	MaxSessionDuration    = time.Hour * 2160
+	MaxSessionDuration    = time.Hour * 24 * 90
 	MinSessionDuration    = time.Minute * 15
 	MinAssumeRoleDuration = time.Minute * 15
 	MaxAssumeRoleDuration = time.Hour * 12


### PR DESCRIPTION
It seems to me that as of today the max Okta session timeout is 90 days.

Could you please help double check this is the fact, and review the PR accordingly, thanks!

