### PR TITLE
fix: Typo in documentation of 'env'

### DIFF
--- a/cmd/env.go
+++ b/cmd/env.go
@@ -17,7 +17,7 @@ var envCmd = &cobra.Command{
 	Use:       "env <profile>",
 	Short:     "env prints out export commands for the specified profile",
 	RunE:      envRun,
-	Example:   "source <$(aws-okta env test)",
+	Example:   "source <(aws-okta env test)",
 	ValidArgs: listProfileNames(mustListProfiles()),
 }
 


### PR DESCRIPTION
source <$(aws-okta env profile) will get you 'no such file or directory: export',
or similar. We just need to execute the command in a subshell.