### PR TITLE
enable prompt if role not provided

### DIFF
--- a/lib/okta.go
+++ b/lib/okta.go
@@ -190,6 +190,7 @@ func (o *OktaClient) AuthenticateProfileWithRegion(profileARN string, duration t
 
 	// Attempt to reuse session cookie
 	var assertion SAMLAssertion
+
 	err := o.Get("GET", o.OktaAwsSAMLUrl, nil, &assertion, "saml")
 	if err != nil {
 		log.Debug("Failed to reuse session token, starting flow from start")

--- a/lib/provider.go
+++ b/lib/provider.go
@@ -220,6 +220,7 @@ func (p *Provider) getSamlSessionCreds() (sts.Credentials, error) {
 			return sts.Credentials{}, errors.New("Source profile must provide `role_arn`")
 		}
 	}
+
 	provider := OktaProvider{
 		MFAConfig:            p.ProviderOptions.MFAConfig,
 		Keyring:              p.keyring,
@@ -250,10 +251,7 @@ func (p *Provider) GetSAMLLoginURL() (*url.URL, error) {
 	}
 	oktaSessionCookieKey := p.getOktaSessionCookieKey()
 
-	profileARN, ok := p.profiles[source]["role_arn"]
-	if !ok {
-		return &url.URL{}, errors.New("Source profile must provide `role_arn`")
-	}
+	profileARN := p.profiles[source]["role_arn"]
 
 	provider := OktaProvider{
 		MFAConfig:            p.ProviderOptions.MFAConfig,

--- a/lib/saml/struct.go
+++ b/lib/saml/struct.go
@@ -2,6 +2,13 @@ package saml
 
 import "encoding/xml"
 
+type AssumableRole struct {
+	Role      string
+	Principal string
+}
+
+type AssumableRoles []AssumableRole
+
 type Response struct {
 	XMLName      xml.Name
 	SAMLP        string `xml:"xmlns:samlp,attr"`


### PR DESCRIPTION
If the `role_arn` is provided, attempt to assume that role. No change to
current behaviour.

If `role_arn` is empty or not present in the profile and there is more than one
role then display the full list of roles the user can assume and prompt
them to choose the role to assume. The choice will be sticky for the
rest of the session for that profile. Whne the session ends they will be
prompted again to choose a role.