### PR TITLE
[WIP] Add U2F support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ vendor/*/
 dist/
 packagecloud.conf.json
 aws-okta
+aws-okta.exe

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/segmentio/aws-okta
 
 require (
 	github.com/99designs/keyring v0.0.0-20181012025958-ff690aee77e9
+	github.com/alessio/shellescape v0.0.0-20190409004728-b115ca0f9053
 	github.com/aulanov/go.dbus v0.0.0-20150729231527-25c3068a42a0 // indirect
 	github.com/aws/aws-sdk-go v0.0.0-20170323003848-3bc643c63c6f
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/99designs/keyring v0.0.0-20180523072454-ccd0779e6f10 h1:sQgghNA6oD/My
 github.com/99designs/keyring v0.0.0-20180523072454-ccd0779e6f10/go.mod h1:aKt8W/yd91/xHY6ixZAJZ2vYbhr3pP8DcrvuGSGNPJk=
 github.com/99designs/keyring v0.0.0-20181012025958-ff690aee77e9 h1:jst3zUpvYIaHu9OIWsR7w6z7a9sDfdWiXRak7URECV8=
 github.com/99designs/keyring v0.0.0-20181012025958-ff690aee77e9/go.mod h1:aKt8W/yd91/xHY6ixZAJZ2vYbhr3pP8DcrvuGSGNPJk=
+github.com/alessio/shellescape v0.0.0-20190409004728-b115ca0f9053 h1:H/GMMKYPkEIC3DF/JWQz8Pdd+Feifov2EIgGfNpeogI=
+github.com/alessio/shellescape v0.0.0-20190409004728-b115ca0f9053/go.mod h1:xW8sBma2LE3QxFSzCnH9qe6gAE2yO9GvQaWwX89HxbE=
 github.com/aulanov/go.dbus v0.0.0-20150729231527-25c3068a42a0 h1:EEDvbomAQ+MFWqJ9FM6RXyJTkc4lckyWsbc5CGQkG1Y=
 github.com/aulanov/go.dbus v0.0.0-20150729231527-25c3068a42a0/go.mod h1:VHvUx+4lTCaJ8zUnEXF4cWEc9c8lnDt4PGLwlZ+3yaM=
 github.com/aws/aws-sdk-go v0.0.0-20170323003848-3bc643c63c6f h1:jUaGnP0b/8/iuYRSz0wldEkOmRa6Veb/bRy55KOdQwQ=

--- a/lib/okta.go
+++ b/lib/okta.go
@@ -364,56 +364,10 @@ func (o *OktaClient) u2fChallenge(oktaFactorID string) ([]byte, error) {
 		KeyHandle: o.UserAuth.Embedded.Factor.Profile.CredentialID,
 	}
 
-	allDevices := u2fhost.Devices()
-	// Filter only the devices that can be opened.
-	openDevices := []u2fhost.Device{}
-	for i, device := range allDevices {
-		err := device.Open()
-		if err == nil {
-			openDevices = append(openDevices, allDevices[i])
-			defer func(i int) {
-				allDevices[i].Close()
-			}(i)
-		}
+	response, err := authenticateU2FRequest(request, o.UserAuth.Embedded.Factor.Embedded.Challenge.TimeoutSeconds)
+	if err != nil {
+		return nil, err
 	}
-
-	authTimeout := o.UserAuth.Embedded.Factor.Embedded.Challenge.TimeoutSeconds
-	if authTimeout == 0 {
-		authTimeout = 20
-	}
-
-	var response *u2fhost.AuthenticateResponse
-	prompted := false
-	timeout := time.After(time.Second * time.Duration(authTimeout))
-	interval := time.NewTicker(time.Millisecond * 250)
-	defer interval.Stop()
-	for {
-		if response != nil {
-			break
-		}
-		select {
-		case <-timeout:
-			log.Infof("Failed to get authentication response after %d seconds", authTimeout)
-			break
-		case <-interval.C:
-			for _, device := range openDevices {
-				response, err = device.Authenticate(request)
-				if err == nil {
-					break
-				} else if _, ok := err.(*u2fhost.TestOfUserPresenceRequiredError); ok {
-					if !prompted {
-						fmt.Println("Touch the flashing U2F device to authenticate...")
-					}
-					prompted = true
-				} else {
-					return nil, err
-				}
-			}
-		}
-	}
-
-	log.Debugf("Client Data: %s", response.ClientData)
-	log.Debugf("Signature Data: %s", response.SignatureData)
 
 	payload, err := json.Marshal(OktaU2FResponse{
 		StateToken:    o.UserAuth.StateToken,

--- a/lib/struct.go
+++ b/lib/struct.go
@@ -11,6 +11,12 @@ type OktaStateToken struct {
 	PassCode   string `json:"passCode"`
 }
 
+type OktaU2FResponse struct {
+	StateToken    string `json:"stateToken"`
+	ClientData    string `json:"clientData"`
+	SignatureData string `json:"signatureData"`
+}
+
 type OktaUserAuthn struct {
 	StateToken   string                `json:"stateToken"`
 	SessionToken string                `json:"sessionToken"`
@@ -21,19 +27,32 @@ type OktaUserAuthn struct {
 }
 
 type OktaUserAuthnEmbedded struct {
-	Factors []OktaUserAuthnFactor `json:"factors"`
-	Factor  OktaUserAuthnFactor   `json:"factor"`
+	User    OktaUserAuthnEmbeddedUser `json:"user"`
+	Factors []OktaUserAuthnFactor     `json:"factors"`
+	Factor  OktaUserAuthnFactor       `json:"factor"`
+}
+
+type OktaUserAuthnEmbeddedUser struct {
+	ID string `json:"id"`
 }
 
 type OktaUserAuthnFactor struct {
 	Id         string                      `json:"id"`
 	FactorType string                      `json:"factorType"`
 	Provider   string                      `json:"provider"`
+	Profile    OktaUserAuthnFactorProfile  `json:"profile"`
 	Embedded   OktaUserAuthnFactorEmbedded `json:"_embedded"`
+}
+
+type OktaUserAuthnFactorProfile struct {
+	CredentialID string `json:"credentialId"`
+	AppID        string `json:"appId"`
+	Version      string `json:"version"`
 }
 
 type OktaUserAuthnFactorEmbedded struct {
 	Verification OktaUserAuthnFactorEmbeddedVerification `json:"verification"`
+	Challenge    OktaUserAuthnFactorEmbeddedChallenge    `json:"challenge"`
 }
 
 type OktaUserAuthnFactorEmbeddedVerification struct {
@@ -43,6 +62,10 @@ type OktaUserAuthnFactorEmbeddedVerification struct {
 	Links        OktaUserAuthnFactorEmbeddedVerificationLinks `json:"_links"`
 }
 
+type OktaUserAuthnFactorEmbeddedChallenge struct {
+	Nonce          string `json:"nonce"`
+	TimeoutSeconds int    `json:"timeoutSeconds"`
+}
 type OktaUserAuthnFactorEmbeddedVerificationLinks struct {
 	Complete OktaUserAuthnFactorEmbeddedVerificationLinksComplete `json:"complete"`
 }

--- a/lib/u2f.go
+++ b/lib/u2f.go
@@ -1,0 +1,62 @@
+package lib
+
+import (
+	"fmt"
+	"time"
+
+	u2fhost "github.com/marshallbrekka/go-u2fhost"
+	log "github.com/sirupsen/logrus"
+)
+
+func authenticateU2FRequest(request *u2fhost.AuthenticateRequest, authTimeout int) (*u2fhost.AuthenticateResponse, error) {
+	allDevices := u2fhost.Devices()
+	// Filter only the devices that can be opened.
+	openDevices := []u2fhost.Device{}
+	for i, device := range allDevices {
+		err := device.Open()
+		if err == nil {
+			openDevices = append(openDevices, allDevices[i])
+			defer func(i int) {
+				allDevices[i].Close()
+			}(i)
+		}
+	}
+
+	if authTimeout == 0 {
+		authTimeout = 20
+	}
+
+	var err error
+	var response *u2fhost.AuthenticateResponse
+	prompted := false
+	timeout := time.After(time.Second * time.Duration(authTimeout))
+	interval := time.NewTicker(time.Millisecond * 250)
+	defer interval.Stop()
+	for {
+		if response != nil {
+			break
+		}
+		select {
+		case <-timeout:
+			log.Infof("Failed to get authentication response after %d seconds", authTimeout)
+			break
+		case <-interval.C:
+			for _, device := range openDevices {
+				response, err = device.Authenticate(request)
+				if err == nil {
+					break
+				} else if _, ok := err.(*u2fhost.TestOfUserPresenceRequiredError); ok {
+					if !prompted {
+						fmt.Println("Touch the flashing U2F device to authenticate...")
+					}
+					prompted = true
+				} else {
+					return nil, err
+				}
+			}
+		}
+	}
+	log.Debugf("Client Data: %s", response.ClientData)
+	log.Debugf("Signature Data: %s", response.SignatureData)
+	return response, nil
+}


### PR DESCRIPTION
This commit adds support for MFA using a U2F device (e.g Yubikey).

Tested and working on Windows.
Example usage:

```
 $ .\aws-okta.exe add
Okta organization: docker

Okta region ([us], emea, preview):

Okta domain [docker.okta.com]:

Okta username: foo@docker.com

Okta password:

time="2019-06-23T20:03:29+01:00" level=info msg="Requesting MFA. Please complete two-factor authentication with your second device"
Touch the flashing U2F device to authenticate...
time="2019-06-23T20:03:33+01:00" level=info msg="Added credentials for user foo@docker.com"
```

```
 $ .\aws-okta.exe login foo
time="2019-06-23T19:59:53+01:00" level=info msg="Requesting MFA. Please complete two-factor authentication with your second device"
Touch the flashing U2F device to authenticate...
```
