### PR TITLE
use debug.BuildInfo to get version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@
 #
 # This makefile is meant for humans
 
-VERSION := $(shell git describe --tags --always --dirty="-dev")
-LDFLAGS := -ldflags='-X "main.Version=$(VERSION)"'
+VERSION := $(shell go list -f '{{ .Module.Version }}' .)
+LDFLAGS :=
 
 test:
 	GO111MODULE=on go test -v ./...

--- a/main.go
+++ b/main.go
@@ -1,14 +1,28 @@
 package main
 
 import (
+	"runtime/debug"
+
 	"github.com/segmentio/aws-okta/cmd"
 )
 
-// These are set via linker flags
 var (
-	Version           = "dev"
 	AnalyticsWriteKey = ""
 )
+
+// overrideable by linker flags, but if not overridden, will be looked up from
+// module build info
+var Version = ""
+
+func init() {
+	if Version != "" {
+		return
+	}
+
+	if buildinfo, ok := debug.ReadBuildInfo(); ok {
+		Version = buildinfo.Main.Version
+	}
+}
 
 func main() {
 	// vars set by linker flags must be strings...


### PR DESCRIPTION
Will probably just close this as it has several problems.

* `go list -f '{{printf "%#v" .Module }}' .` seems to always print `""`, even in a clean checkout with a tag on HEAD
* Builds in the git tree always seem to yield a version of `(devel)` :/

The only way I could actually get build info was with 
```
$ cd ~/tmp/blah
$ export GOPATH=`pwd`
$ GO111MODULE=on go get github.com/segmentio/aws-okta@v0.21.1-versionfrombuildinfotest
$ ./bin/aws-okta version
aws-okta v0.21.1-versionfrombuildinfotest
```