### PR TITLE
Enable Shorthand Flag for Stdout on the Login Command

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -30,7 +30,7 @@ var Stdout bool
 
 func init() {
 	RootCmd.AddCommand(loginCmd)
-	loginCmd.Flags().BoolVarP(&Stdout, "stdout", "", false, "Print login URL to stdout instead of opening in default browser")
+	loginCmd.Flags().BoolVarP(&Stdout, "stdout", "s", false, "Print login URL to stdout instead of opening in default browser")
 	loginCmd.Flags().DurationVarP(&sessionTTL, "session-ttl", "t", time.Hour, "Expiration time for okta role session")
 	loginCmd.Flags().DurationVarP(&assumeRoleTTL, "assume-role-ttl", "a", time.Hour, "Expiration time for assumed role")
 }


### PR DESCRIPTION
Heyo,

Super minor change - I'm currently in the process of migrating from `aws-vault` to `aws-okta` and a frequent use case I have is

```shell
$ aws-vault login -s profile | pbcopy
```

and then opening the link in a new private browser session.

I noticed that `aws-okta` doesn't provide a shorthand option for the flag and requires typing out `-stdout` each time; this PR enables usage of the shorthand `-s` flag.