### PR TITLE
feat: role flag for exec

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -21,14 +21,15 @@ import (
 var (
 	sessionTTL    time.Duration
 	assumeRoleTTL time.Duration
+	assumeRoleARN string
 )
 
 func mustListProfiles() lib.Profiles {
-  profiles, err := listProfiles()
-  if err != nil {
-    log.Panicf("Failed to list profiles: %v", err)
-  }
-  return profiles
+	profiles, err := listProfiles()
+	if err != nil {
+		log.Panicf("Failed to list profiles: %v", err)
+	}
+	return profiles
 }
 
 // execCmd represents the exec command
@@ -44,6 +45,7 @@ func init() {
 	RootCmd.AddCommand(execCmd)
 	execCmd.Flags().DurationVarP(&sessionTTL, "session-ttl", "t", time.Hour, "Expiration time for okta role session")
 	execCmd.Flags().DurationVarP(&assumeRoleTTL, "assume-role-ttl", "a", time.Hour, "Expiration time for assumed role")
+	execCmd.Flags().StringVarP(&assumeRoleARN, "assume-role", "r", "", "Assume a specified role using the role ARN")
 }
 
 func loadDurationFlagFromEnv(cmd *cobra.Command, flagName string, envVar string, val *time.Duration) error {
@@ -124,7 +126,9 @@ func execRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if _, ok := profiles[profile]; !ok {
+	if _, ok := profiles[profile]; ok {
+		profiles[profile]["role_arn"] = assumeRoleARN
+	} else {
 		return fmt.Errorf("Profile '%s' not found in your aws config. Use list command to see configured profiles.", profile)
 	}
 


### PR DESCRIPTION
This lets the user specify a role ARN with the `-r` flag to assume the
specified role.