### PR TITLE
feat: adding current role as env var

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -24,11 +24,11 @@ var (
 )
 
 func mustListProfiles() lib.Profiles {
-  profiles, err := listProfiles()
-  if err != nil {
-    log.Panicf("Failed to list profiles: %v", err)
-  }
-  return profiles
+	profiles, err := listProfiles()
+	if err != nil {
+		log.Panicf("Failed to list profiles: %v", err)
+	}
+	return profiles
 }
 
 // execCmd represents the exec command
@@ -176,6 +176,12 @@ func execRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	roleARN, err := p.GetRoleARN()
+	if err != nil {
+		return err
+	}
+	role := strings.Split(roleARN, "/")[1]
+
 	env := environ(os.Environ())
 	env.Unset("AWS_ACCESS_KEY_ID")
 	env.Unset("AWS_SECRET_ACCESS_KEY")
@@ -192,6 +198,8 @@ func execRun(cmd *cobra.Command, args []string) error {
 	env.Set("AWS_ACCESS_KEY_ID", creds.AccessKeyID)
 	env.Set("AWS_SECRET_ACCESS_KEY", creds.SecretAccessKey)
 	env.Set("AWS_OKTA_PROFILE", profile)
+	env.Set("AWS_OKTA_ASSUMED_ROLE_ARN", roleARN)
+	env.Set("AWS_OKTA_ASSUMED_ROLE", role)
 
 	if creds.SessionToken != "" {
 		env.Set("AWS_SESSION_TOKEN", creds.SessionToken)

--- a/lib/provider.go
+++ b/lib/provider.go
@@ -248,3 +248,23 @@ func (p *Provider) roleSessionName() string {
 	// Try to work out a role name that will hopefully end up unique.
 	return fmt.Sprintf("%d", time.Now().UTC().UnixNano())
 }
+
+func (p *Provider) GetRoleARN() (string, error) {
+	source := sourceProfile(p.profile, p.profiles)
+	creds, _, err := p.sessions.Retrieve(source, p.SessionDuration)
+	if err != nil {
+		return "", err
+	}
+	client := sts.New(session.New(&aws.Config{Credentials: credentials.NewStaticCredentials(
+		*creds.AccessKeyId,
+		*creds.SecretAccessKey,
+		*creds.SessionToken,
+	)}))
+
+	indentity, err := client.GetCallerIdentity(&sts.GetCallerIdentityInput{})
+	if err != nil {
+		return "", err
+	}
+	arn := *indentity.Arn
+	return arn, nil
+}


### PR DESCRIPTION
Storing current AWS assumed-role as `AWS_ROLE`. This allows the user to
easily check the assumed role when running aws-okta.