### PR TITLE
feat: support for aws govcloud profiles

### DIFF
--- a/lib/okta.go
+++ b/lib/okta.go
@@ -555,7 +555,7 @@ type OktaProvider struct {
 	// to be stored in the keyring.
 	OktaSessionCookieKey string
 	MFAConfig            MFAConfig
-	AwsRegion  string
+	AwsRegion            string
 }
 
 func (p *OktaProvider) Retrieve() (sts.Credentials, string, error) {

--- a/lib/okta.go
+++ b/lib/okta.go
@@ -185,7 +185,7 @@ func (o *OktaClient) AuthenticateUser() error {
 	return nil
 }
 
-func (o *OktaClient) AuthenticateProfile(profileARN string, duration time.Duration, region string) (sts.Credentials, string, error) {
+func (o *OktaClient) AuthenticateProfileWithRegion(profileARN string, duration time.Duration, region string) (sts.Credentials, string, error) {
 
 	// Attempt to reuse session cookie
 	var assertion SAMLAssertion
@@ -247,6 +247,11 @@ func (o *OktaClient) AuthenticateProfile(profileARN string, duration time.Durati
 	}
 
 	return *samlResp.Credentials, sessionCookie, nil
+}
+
+
+func (o *OktaClient) AuthenticateProfile(profileARN string, duration time.Duration) (sts.Credentials, string, error) {
+    return o.AuthenticateProfileWithRegion(profileARN, duration, "")
 }
 
 func selectMFADeviceFromConfig(o *OktaClient) (*OktaUserAuthnFactor, error) {
@@ -583,7 +588,7 @@ func (p *OktaProvider) Retrieve() (sts.Credentials, string, error) {
 		return sts.Credentials{}, "", err
 	}
 
-	creds, newSessionCookie, err := oktaClient.AuthenticateProfile(p.ProfileARN, p.SessionDuration, p.AwsRegion)
+	creds, newSessionCookie, err := oktaClient.AuthenticateProfileWithRegion(p.ProfileARN, p.SessionDuration, p.AwsRegion)
 	if err != nil {
 		return sts.Credentials{}, "", err
 	}

--- a/lib/okta.go
+++ b/lib/okta.go
@@ -555,7 +555,7 @@ type OktaProvider struct {
 	// to be stored in the keyring.
 	OktaSessionCookieKey string
 	MFAConfig            MFAConfig
-	AwsRegion			 string
+	AwsRegion  string
 }
 
 func (p *OktaProvider) Retrieve() (sts.Credentials, string, error) {

--- a/lib/provider.go
+++ b/lib/provider.go
@@ -221,6 +221,10 @@ func (p *Provider) getSamlSessionCreds() (sts.Credentials, error) {
 		OktaAwsSAMLUrl:       oktaAwsSAMLUrl,
 		OktaSessionCookieKey: oktaSessionCookieKey,
 	}
+	
+	if region := p.profiles[source]["region"]; region != "" {
+		provider.AwsRegion = region
+	}
 
 	creds, oktaUsername, err := provider.Retrieve()
 	if err != nil {
@@ -251,6 +255,10 @@ func (p *Provider) GetSAMLLoginURL() (*url.URL, error) {
 		SessionDuration:      p.SessionDuration,
 		OktaAwsSAMLUrl:       oktaAwsSAMLUrl,
 		OktaSessionCookieKey: oktaSessionCookieKey,
+	}
+
+	if region := p.profiles[source]["region"]; region != "" {
+		provider.AwsRegion = region
 	}
 
 	loginURL, err := provider.GetSAMLLoginURL()


### PR DESCRIPTION
Currently this project assumes we would always want to use us-gov-west-1 as it is statically set https://github.com/segmentio/aws-okta/blob/master/lib/okta.go#L217. This PR adds support so it is region agnostic. 