### PR TITLE
fix: don't force reauth when calling GetRoleARN

### DIFF
--- a/cmd/env.go
+++ b/cmd/env.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/99designs/keyring"
 	"github.com/alessio/shellescape"
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	analytics "github.com/segmentio/analytics-go"
 	"github.com/segmentio/aws-okta/lib"
 	"github.com/spf13/cobra"
@@ -98,7 +99,12 @@ func envRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	roleARN, err := p.GetRoleARN(&creds)
+	// TODO: deduplicate this code from exec.go
+	roleARN, err := lib.GetRoleARN(credentials.Value{
+		AccessKeyID:     creds.AccessKeyID,
+		SecretAccessKey: creds.SecretAccessKey,
+		SessionToken:    creds.SessionToken,
+	})
 	if err != nil {
 		return err
 	}

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/99designs/keyring"
@@ -97,9 +98,17 @@ func envRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	roleARN, err := p.GetRoleARN(&creds)
+	if err != nil {
+		return err
+	}
+	role := strings.Split(roleARN, "/")[1]
+
 	fmt.Printf("export AWS_ACCESS_KEY_ID=%s\n", shellescape.Quote(creds.AccessKeyID))
 	fmt.Printf("export AWS_SECRET_ACCESS_KEY=%s\n", shellescape.Quote(creds.SecretAccessKey))
 	fmt.Printf("export AWS_OKTA_PROFILE=%s\n", shellescape.Quote(profile))
+	fmt.Printf("export AWS_OKTA_ASSUMED_ROLE_ARN=%s\n", shellescape.Quote(roleARN))
+	fmt.Printf("export AWS_OKTA_ASSUMED_ROLE=%s\n", shellescape.Quote(role))
 
 	if region, ok := profiles[profile]["region"]; ok {
 		fmt.Printf("export AWS_DEFAULT_REGION=%s\n", shellescape.Quote(region))

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	log "github.com/sirupsen/logrus"
 
 	"os"
@@ -178,7 +179,11 @@ func execRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	roleARN, err := p.GetRoleARN(&creds)
+	roleARN, err := lib.GetRoleARN(credentials.Value{
+		AccessKeyID:     creds.AccessKeyID,
+		SecretAccessKey: creds.SecretAccessKey,
+		SessionToken:    creds.SessionToken,
+	})
 	if err != nil {
 		return err
 	}

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -178,7 +178,7 @@ func execRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	roleARN, err := p.GetRoleARN()
+	roleARN, err := p.GetRoleARN(&creds)
 	if err != nil {
 		return err
 	}

--- a/lib/provider.go
+++ b/lib/provider.go
@@ -307,19 +307,18 @@ func (p *Provider) roleSessionName() string {
 	return fmt.Sprintf("%d", time.Now().UTC().UnixNano())
 }
 
-func (p *Provider) GetRoleARN() (string, error) {
-	creds, err := p.getSamlSessionCreds()
-	if err != nil {
-		return "", err
-	}
+// GetRoleARN makes a call to AWS to get-caller-identity and returns the
+// assumed role's name and ARN.
+func (p *Provider) GetRoleARN(c *credentials.Value) (string, error) {
 	client := sts.New(aws_session.New(&aws.Config{Credentials: credentials.NewStaticCredentials(
-		*creds.AccessKeyId,
-		*creds.SecretAccessKey,
-		*creds.SessionToken,
+		c.AccessKeyID,
+		c.SecretAccessKey,
+		c.SessionToken,
 	)}))
 
 	indentity, err := client.GetCallerIdentity(&sts.GetCallerIdentityInput{})
 	if err != nil {
+		log.Errorf("Error getting caller identity: %s", err.Error())
 		return "", err
 	}
 	arn := *indentity.Arn

--- a/lib/provider.go
+++ b/lib/provider.go
@@ -221,7 +221,7 @@ func (p *Provider) getSamlSessionCreds() (sts.Credentials, error) {
 		OktaAwsSAMLUrl:       oktaAwsSAMLUrl,
 		OktaSessionCookieKey: oktaSessionCookieKey,
 	}
-	
+
 	if region := p.profiles[source]["region"]; region != "" {
 		provider.AwsRegion = region
 	}
@@ -307,14 +307,24 @@ func (p *Provider) roleSessionName() string {
 	return fmt.Sprintf("%d", time.Now().UTC().UnixNano())
 }
 
+// GetRoleARN uses p to establish temporary credentials then calls
+// lib.GetRoleARN with them to get the role's ARN
+func (p *Provider) GetRoleARN() (string, error) {
+	creds, err := p.getSamlSessionCreds()
+	if err != nil {
+		return "", err
+	}
+	return GetRoleARN(credentials.Value{
+		AccessKeyID:     *creds.AccessKeyId,
+		SecretAccessKey: *creds.SecretAccessKey,
+		SessionToken:    *creds.SessionToken,
+	})
+}
+
 // GetRoleARN makes a call to AWS to get-caller-identity and returns the
 // assumed role's name and ARN.
-func (p *Provider) GetRoleARN(c *credentials.Value) (string, error) {
-	client := sts.New(aws_session.New(&aws.Config{Credentials: credentials.NewStaticCredentials(
-		c.AccessKeyID,
-		c.SecretAccessKey,
-		c.SessionToken,
-	)}))
+func GetRoleARN(c credentials.Value) (string, error) {
+	client := sts.New(aws_session.New(&aws.Config{Credentials: credentials.NewStaticCredentialsFromCreds(c)}))
 
 	indentity, err := client.GetCallerIdentity(&sts.GetCallerIdentityInput{})
 	if err != nil {


### PR DESCRIPTION
The call to `p.GetRoleArn()` added in https://github.com/segmentio/aws-okta/commit/396d453 was forcing a separate auth event. That broke session caching in 0.23.0 and 0.23.1.

So the first run of `aws-okta` would auth twice, including a second 2FA prompt. Every subsequent call to `aws-okta` then also required 2FA confirmation.

This PR modifies GetRoleARN to take the creds as an argument.  Those creds are fetched immediately before anyways.

This also adds the `AWS_OKTA_ASSUMED_ROLE_ARN` and `AWS_OKTA_ASSUMED_ROLE` environment variables to the `env` subcommand so that it is consistent with `exec`.

This replaces a couple other PRs:

Closes: #216
Closes: #217
