### PR TITLE
feat: Support for multiple Okta accounts (add keyring key configuration per profile)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,8 @@ The configuration above means that you can use multiple Okta Apps at the same ti
 #### Multiple Okta accounts
 setup accounts:
 ```ini
-aws-okta add --keyringKey=okta-creds-account-a
-aws-okta add --keyringKey=okta-creds-account-b
+aws-okta add --account=account-a
+aws-okta add --account=account-b
 ```
 
 define keyring key for each profile:
@@ -139,12 +139,12 @@ define keyring key for each profile:
 # This is a distinct Okta App
 aws_saml_url = home/amazon_aws/woezQTbGWUaLSrYDvINU/214
 role_arn = arn:aws:iam::<account-id>:role/<okta-role-name>
-okta_keyring_key = okta-creds-account-a
+okta_account_name = account-a
 
 [profile account-b]
 aws_saml_url = home/amazon_aws/woezQTbGaDAA4rYDvINU/123
 role_arn = arn:aws:iam::<account-id>:role/<okta-role-name>
-okta_keyring_key = okta-creds-account-b
+okta_account_name = account-b
 ```
 
 #### Configuring Okta session and AWS assume role TTLs

--- a/README.md
+++ b/README.md
@@ -126,6 +126,27 @@ role_arn = arn:aws:iam::<account-id>:role/<okta-role-name>
 
 The configuration above means that you can use multiple Okta Apps at the same time and switch between them easily.
 
+#### Multiple Okta accounts
+setup accounts:
+```ini
+aws-okta add --keyringKey=okta-creds-account-a
+aws-okta add --keyringKey=okta-creds-account-b
+```
+
+define keyring key for each profile:
+```ini
+[profile account-a]
+# This is a distinct Okta App
+aws_saml_url = home/amazon_aws/woezQTbGWUaLSrYDvINU/214
+role_arn = arn:aws:iam::<account-id>:role/<okta-role-name>
+okta_keyring_key = okta-creds-account-a
+
+[profile account-b]
+aws_saml_url = home/amazon_aws/woezQTbGaDAA4rYDvINU/123
+role_arn = arn:aws:iam::<account-id>:role/<okta-role-name>
+okta_keyring_key = okta-creds-account-b
+```
+
 #### Configuring Okta session and AWS assume role TTLs
 
 The default TTLs for both Okta sessions and AWS assumed roles is 1 hour.  This means that aws-okta will re-authenticate to Okta and AWS credentials will expire every hour.  In addition to specifying the Okta session and AWS assume role TTLs with the command-line flags, they can be set using the `AWS_SESSION_TTL` and `AWS_ASSUME_ROLE_TTL` environment variables respectively.

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -13,10 +13,10 @@ import (
 )
 
 var (
-	organization string
-	oktaDomain   string
-	oktaRegion   string
-	keyringKey   string
+	organization    string
+	oktaDomain      string
+	oktaRegion      string
+	oktaAccountName string
 )
 
 // addCmd represents the add command
@@ -30,7 +30,7 @@ func init() {
 	RootCmd.AddCommand(addCmd)
 	addCmd.Flags().StringVarP(&oktaDomain, "domain", "", "", "Okta domain (e.g. <orgname>.okta.com)")
 	addCmd.Flags().StringVarP(&username, "username", "", "", "Okta username")
-	addCmd.Flags().StringVarP(&keyringKey, "keyringKey", "", "", "Keyring key")
+	addCmd.Flags().StringVarP(&oktaAccountName, "account", "", "", "Okta account name")
 }
 
 func add(cmd *cobra.Command, args []string) error {
@@ -92,10 +92,12 @@ func add(cmd *cobra.Command, args []string) error {
 		}
 	}
 	
-	if keyringKey == "" {
-	    keyringKey = "okta-creds"
+	if oktaAccountName == "" {
+	    oktaAccountName = "okta-creds"
+	} else {
+	    oktaAccountName = "okta-creds-" + oktaAccountName
 	}
-	log.Debugf("okta-keyring-key: %s", keyringKey)
+	log.Debugf("keyring key: %s", oktaAccountName)
 
 	// Ask for password from prompt
 	password, err := lib.Prompt("Okta password", true)
@@ -127,7 +129,7 @@ func add(cmd *cobra.Command, args []string) error {
 	}
 
 	item := keyring.Item{
-		Key:                         keyringKey,
+		Key:                         oktaAccountName,
 		Data:                        encoded,
 		Label:                       "okta credentials",
 		KeychainNotTrustApplication: false,

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -97,7 +97,7 @@ func add(cmd *cobra.Command, args []string) error {
 	} else {
 	    oktaAccountName = "okta-creds-" + oktaAccountName
 	}
-	log.Debugf("keyring key: %s", oktaAccountName)
+	log.Debugf("Keyring key: %s", oktaAccountName)
 
 	// Ask for password from prompt
 	password, err := lib.Prompt("Okta password", true)

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -16,6 +16,7 @@ var (
 	organization string
 	oktaDomain   string
 	oktaRegion   string
+	keyringKey   string
 )
 
 // addCmd represents the add command
@@ -29,6 +30,7 @@ func init() {
 	RootCmd.AddCommand(addCmd)
 	addCmd.Flags().StringVarP(&oktaDomain, "domain", "", "", "Okta domain (e.g. <orgname>.okta.com)")
 	addCmd.Flags().StringVarP(&username, "username", "", "", "Okta username")
+	addCmd.Flags().StringVarP(&keyringKey, "keyringKey", "", "", "Keyring key")
 }
 
 func add(cmd *cobra.Command, args []string) error {
@@ -89,6 +91,11 @@ func add(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	}
+	
+	if keyringKey == "" {
+	    keyringKey = "okta-creds"
+	}
+	log.Debugf("okta-keyring-key: %s", keyringKey)
 
 	// Ask for password from prompt
 	password, err := lib.Prompt("Okta password", true)
@@ -120,7 +127,7 @@ func add(cmd *cobra.Command, args []string) error {
 	}
 
 	item := keyring.Item{
-		Key:                         "okta-creds",
+		Key:                         keyringKey,
 		Data:                        encoded,
 		Label:                       "okta credentials",
 		KeychainNotTrustApplication: false,

--- a/lib/okta.go
+++ b/lib/okta.go
@@ -596,10 +596,10 @@ type OktaProvider struct {
 }
 
 func (p *OktaProvider) Retrieve() (sts.Credentials, string, error) {
-	log.Debug("using okta provider (%s)", p.OktaAccountName)
+	log.Debugf("Using okta provider (%s)", p.OktaAccountName)
 	item, err := p.Keyring.Get(p.OktaAccountName)
 	if err != nil {
-		log.Debugf("couldnt get okta creds from keyring: %s", err)
+		log.Debugf("Couldnt get okta creds from keyring: %s", err)
 		return sts.Credentials{}, "", err
 	}
 

--- a/lib/okta.go
+++ b/lib/okta.go
@@ -590,14 +590,14 @@ type OktaProvider struct {
 	// OktaSessionCookieKey represents the name of the session cookie
 	// to be stored in the keyring.
 	OktaSessionCookieKey string
-	OktaKeyringKey string
+	OktaAccountName      string
 	MFAConfig            MFAConfig
 	AwsRegion            string
 }
 
 func (p *OktaProvider) Retrieve() (sts.Credentials, string, error) {
-	log.Debug("using okta provider")
-	item, err := p.Keyring.Get(p.OktaKeyringKey)
+	log.Debug("using okta provider (%s)", p.OktaAccountName)
+	item, err := p.Keyring.Get(p.OktaAccountName)
 	if err != nil {
 		log.Debugf("couldnt get okta creds from keyring: %s", err)
 		return sts.Credentials{}, "", err

--- a/lib/okta.go
+++ b/lib/okta.go
@@ -590,13 +590,14 @@ type OktaProvider struct {
 	// OktaSessionCookieKey represents the name of the session cookie
 	// to be stored in the keyring.
 	OktaSessionCookieKey string
+	OktaKeyringKey string
 	MFAConfig            MFAConfig
 	AwsRegion            string
 }
 
 func (p *OktaProvider) Retrieve() (sts.Credentials, string, error) {
 	log.Debug("using okta provider")
-	item, err := p.Keyring.Get("okta-creds")
+	item, err := p.Keyring.Get(p.OktaKeyringKey)
 	if err != nil {
 		log.Debugf("couldnt get okta creds from keyring: %s", err)
 		return sts.Credentials{}, "", err

--- a/lib/provider.go
+++ b/lib/provider.go
@@ -205,7 +205,7 @@ func (p *Provider) getOktaAccountName() string {
 	if err != nil {
 		return "okta-creds"
 	}
-	log.Debugf("Using okta_account_name from profile: %s", profile)
+	log.Debugf("Using okta_account_name from profile: %s", oktaAccountName)
 	return "okta-creds-" + oktaAccountName
 }
 

--- a/lib/provider.go
+++ b/lib/provider.go
@@ -200,6 +200,15 @@ func (p *Provider) getOktaSessionCookieKey() string {
 	return oktaSessionCookieKey
 }
 
+func (p *Provider) getOktaKeyringKey() string {
+	oktaKeyringKey, profile, err := p.profiles.GetValue(p.profile, "okta_keyring_key")
+	if err != nil {
+		return "okta-creds"
+	}
+	log.Debugf("Using okta_keyring_key from profile: %s", profile)
+	return oktaKeyringKey
+}
+
 func (p *Provider) getSamlSessionCreds() (sts.Credentials, error) {
 	var profileARN string
 	var ok bool
@@ -209,6 +218,7 @@ func (p *Provider) getSamlSessionCreds() (sts.Credentials, error) {
 		return sts.Credentials{}, err
 	}
 	oktaSessionCookieKey := p.getOktaSessionCookieKey()
+	oktaKeyringKey := p.getOktaKeyringKey()
 
 	// if the assumable role is passed it have it override what is in the profile
 	if p.AssumeRoleArn != "" {
@@ -228,6 +238,7 @@ func (p *Provider) getSamlSessionCreds() (sts.Credentials, error) {
 		SessionDuration:      p.SessionDuration,
 		OktaAwsSAMLUrl:       oktaAwsSAMLUrl,
 		OktaSessionCookieKey: oktaSessionCookieKey,
+		OktaKeyringKey: oktaKeyringKey,
 	}
 
 	if region := p.profiles[source]["region"]; region != "" {
@@ -250,6 +261,7 @@ func (p *Provider) GetSAMLLoginURL() (*url.URL, error) {
 		return &url.URL{}, err
 	}
 	oktaSessionCookieKey := p.getOktaSessionCookieKey()
+	oktaKeyringKey := p.getOktaKeyringKey()
 
 	profileARN := p.profiles[source]["role_arn"]
 
@@ -260,6 +272,7 @@ func (p *Provider) GetSAMLLoginURL() (*url.URL, error) {
 		SessionDuration:      p.SessionDuration,
 		OktaAwsSAMLUrl:       oktaAwsSAMLUrl,
 		OktaSessionCookieKey: oktaSessionCookieKey,
+		OktaKeyringKey: oktaKeyringKey,
 	}
 
 	if region := p.profiles[source]["region"]; region != "" {

--- a/lib/provider.go
+++ b/lib/provider.go
@@ -200,13 +200,13 @@ func (p *Provider) getOktaSessionCookieKey() string {
 	return oktaSessionCookieKey
 }
 
-func (p *Provider) getOktaKeyringKey() string {
-	oktaKeyringKey, profile, err := p.profiles.GetValue(p.profile, "okta_keyring_key")
+func (p *Provider) getOktaAccountName() string {
+	oktaAccountName, profile, err := p.profiles.GetValue(p.profile, "okta_account_name")
 	if err != nil {
 		return "okta-creds"
 	}
-	log.Debugf("Using okta_keyring_key from profile: %s", profile)
-	return oktaKeyringKey
+	log.Debugf("Using okta_account_name from profile: %s", profile)
+	return "okta-creds-" + oktaAccountName
 }
 
 func (p *Provider) getSamlSessionCreds() (sts.Credentials, error) {
@@ -218,7 +218,7 @@ func (p *Provider) getSamlSessionCreds() (sts.Credentials, error) {
 		return sts.Credentials{}, err
 	}
 	oktaSessionCookieKey := p.getOktaSessionCookieKey()
-	oktaKeyringKey := p.getOktaKeyringKey()
+	oktaAccountName := p.getOktaAccountName()
 
 	// if the assumable role is passed it have it override what is in the profile
 	if p.AssumeRoleArn != "" {
@@ -238,7 +238,7 @@ func (p *Provider) getSamlSessionCreds() (sts.Credentials, error) {
 		SessionDuration:      p.SessionDuration,
 		OktaAwsSAMLUrl:       oktaAwsSAMLUrl,
 		OktaSessionCookieKey: oktaSessionCookieKey,
-		OktaKeyringKey: oktaKeyringKey,
+		OktaAccountName:      oktaAccountName,
 	}
 
 	if region := p.profiles[source]["region"]; region != "" {
@@ -261,7 +261,7 @@ func (p *Provider) GetSAMLLoginURL() (*url.URL, error) {
 		return &url.URL{}, err
 	}
 	oktaSessionCookieKey := p.getOktaSessionCookieKey()
-	oktaKeyringKey := p.getOktaKeyringKey()
+	oktaAccountName := p.getOktaAccountName()
 
 	profileARN := p.profiles[source]["role_arn"]
 
@@ -272,7 +272,7 @@ func (p *Provider) GetSAMLLoginURL() (*url.URL, error) {
 		SessionDuration:      p.SessionDuration,
 		OktaAwsSAMLUrl:       oktaAwsSAMLUrl,
 		OktaSessionCookieKey: oktaSessionCookieKey,
-		OktaKeyringKey: oktaKeyringKey,
+		OktaAccountName:      oktaAccountName,
 	}
 
 	if region := p.profiles[source]["region"]; region != "" {

--- a/lib/provider.go
+++ b/lib/provider.go
@@ -205,7 +205,7 @@ func (p *Provider) getOktaAccountName() string {
 	if err != nil {
 		return "okta-creds"
 	}
-	log.Debugf("Using okta_account_name from profile: %s", oktaAccountName)
+	log.Debugf("Using okta_account_name: %s from profile: %s", oktaAccountName, profile)
 	return "okta-creds-" + oktaAccountName
 }
 


### PR DESCRIPTION
Add ability for user to specify keyring key to separate provider data (including MFA and domain) per aws profile. Similar to #91 request.

Setup accounts:
```ini
aws-okta add --keyringKey=okta-creds-account-a
aws-okta add --keyringKey=okta-creds-account-b
```

Define keyring key for each profile:
```ini
[profile account-a]
aws_saml_url = home/amazon_aws/woezQTbGWUaLSrYDvINU/214
role_arn = arn:aws:iam::<account-id>:role/<okta-role-name>
okta_keyring_key = okta-creds-account-a

[profile account-b]
aws_saml_url = home/amazon_aws/adbcQTbGaDAA4rYDvINU/123
role_arn = arn:aws:iam::<account-id>:role/<okta-role-name>
okta_keyring_key = okta-creds-account-b
```
