### PR TITLE
Add credential_process support

### DIFF
--- a/cmd/cred-process.go
+++ b/cmd/cred-process.go
@@ -1,0 +1,137 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/99designs/keyring"
+	analytics "github.com/segmentio/analytics-go"
+	"github.com/segmentio/aws-okta/lib"
+	"github.com/spf13/cobra"
+)
+
+const credProcessVersion = 1
+
+var pretty bool
+
+type credProcess struct {
+	Version         int    `json:"Version"`
+	AccessKeyID     string `json:"AccessKeyId"`
+	SecretAccessKey string `json:"SecretAccessKey"`
+	SessionToken    string `json:"SessionToken"`
+	Expiration      string `json:"Expiration"`
+}
+
+// credProcessCmd represents the cred-process command
+var credProcessCmd = &cobra.Command{
+	Use:       "cred-process <profile>",
+	Short:     "cred-process generates a credential_process ready output",
+	RunE:      credProcessRun,
+	Example:   "[profile foo]\ncredential_process = aws-okta cred-process profile",
+	ValidArgs: listProfileNames(mustListProfiles()),
+}
+
+func init() {
+	RootCmd.AddCommand(credProcessCmd)
+	credProcessCmd.Flags().DurationVarP(&sessionTTL, "session-ttl", "t", time.Hour, "Expiration time for okta role session")
+	credProcessCmd.Flags().DurationVarP(&assumeRoleTTL, "assume-role-ttl", "a", time.Hour, "Expiration time for assumed role")
+	credProcessCmd.Flags().BoolVarP(&pretty, "pretty", "p", false, "Pretty print display")
+}
+
+func credProcessRun(cmd *cobra.Command, args []string) error {
+	if len(args) < 1 {
+		return ErrTooFewArguments
+	}
+
+	profile := args[0]
+	config, err := lib.NewConfigFromEnv()
+	if err != nil {
+		return err
+	}
+
+	profiles, err := config.Parse()
+	if err != nil {
+		return err
+	}
+
+	if _, ok := profiles[profile]; !ok {
+		return fmt.Errorf("Profile '%s' not found in your aws config. Use list command to see configured profiles", profile)
+	}
+
+	updateMfaConfig(cmd, profiles, profile, &mfaConfig)
+
+	// check for an assume_role_ttl in the profile if we don't have a more explicit one
+	if !cmd.Flags().Lookup("assume-role-ttl").Changed {
+		if err := updateDurationFromConfigProfile(profiles, profile, &assumeRoleTTL); err != nil {
+			fmt.Fprintln(os.Stderr, "warning: could not parse duration from profile config")
+		}
+	}
+
+	opts := lib.ProviderOptions{
+		MFAConfig:          mfaConfig,
+		Profiles:           profiles,
+		SessionDuration:    sessionTTL,
+		AssumeRoleDuration: assumeRoleTTL,
+	}
+
+	var allowedBackends []keyring.BackendType
+	if backend != "" {
+		allowedBackends = append(allowedBackends, keyring.BackendType(backend))
+	}
+
+	kr, err := lib.OpenKeyring(allowedBackends)
+	if err != nil {
+		return err
+	}
+
+	if analyticsEnabled && analyticsClient != nil {
+		analyticsClient.Enqueue(analytics.Track{
+			UserId: username,
+			Event:  "Ran Command",
+			Properties: analytics.NewProperties().
+				Set("backend", backend).
+				Set("aws-okta-version", version).
+				Set("profile", profile).
+				Set("command", "cred-process"),
+		})
+	}
+
+	opts.SessionCacheSingleItem = flagSessionCacheSingleItem
+
+	p, err := lib.NewProvider(kr, profile, opts)
+	if err != nil {
+		return err
+	}
+
+	creds, err := p.Retrieve()
+	if err != nil {
+		return err
+	}
+
+	// builds the result struct
+	cp := credProcess{
+		Version:         credProcessVersion,
+		AccessKeyID:     creds.AccessKeyID,
+		SecretAccessKey: creds.SecretAccessKey,
+		SessionToken:    creds.SessionToken,
+		// reuse the provided session duration
+		Expiration: time.Now().Add(p.SessionDuration).Format(time.RFC3339),
+	}
+
+	var output []byte
+
+	if pretty {
+		output, err = json.MarshalIndent(cp, "", "    ")
+	} else {
+		output, err = json.Marshal(cp)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(output))
+	return nil
+}


### PR DESCRIPTION
Hello there,

I was reading #143 and because I'm in the same situation where I need to use `credential_process`, I made a quick PR.

Here's the new command help:

```
$ aws-okta help cred-process
cred-process generates a credential_process ready output

Usage:
  aws-okta cred-process <profile> [flags]

Examples:
[profile foo]
credential_process = aws-okta cred-process profile

Flags:
  -a, --assume-role-ttl duration   Expiration time for assumed role (default 1h0m0s)
  -h, --help                       help for cred-process
  -p, --pretty                     Pretty print display
  -t, --session-ttl duration       Expiration time for okta role session (default 1h0m0s)

Global Flags:
  -b, --backend string              Secret backend to use [keychain pass file]
  -d, --debug                       Enable debug logging
      --mfa-duo-device string       Device to use phone1, phone2, u2f or token (default "phone1")
      --mfa-factor-type string      MFA Factor Type to use (eg push, token:software:totp)
      --mfa-provider string         MFA Provider to use (eg DUO, OKTA, GOOGLE)
      --session-cache-single-item   (alpha) Enable single-item session cache; aka AWS_OKTA_SESSION_CACHE_SINGLE_ITEM
```

Output sample (with the `--pretty` flag):

```
 $ aws-okta cred-process --pretty foo
{
    "Version": 1,
    "AccessKeyId": "XXXXXXXXXXXX",
    "SecretAccessKey": "YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY",
    "SessionToken": "FQoGZXIvYXdzEKX//////////.....TbnvyOil30UGukQQVEQABIvE4L/x7F1//Ui21d3bsB34yq99yLZRjV3I995JEDB........WQAPKjLDpKNej7uwF",
    "Expiration": "2019-10-07T22:47:11+02:00"
}
```

Hope this helps.

Thanks!