### PR TITLE
docs: Adds shell completion section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,10 @@ If you have a single MFA factor configured, that factor will be automatically se
 * Specify with environment variables `AWS_OKTA_MFA_PROVIDER` and `AWS_OKTA_MFA_FACTOR_TYPE`
 * Specify in your aws config with `mfa_provider` and `mfa_factor_type`
 
+### Shell completion
+
+`aws-okta` provides shell completion support for BASH and ZSH via the `aws-okta completion` command.
+
 ## Backends
 
 We use 99design's keyring package that they use in `aws-vault`.  Because of this, you can choose between different pluggable secret storage backends just like in `aws-vault`.  You can either set your backend from the command line as a flag, or set the `AWS_OKTA_BACKEND` environment variable.


### PR DESCRIPTION
I looked for auto-completion for `aws-okta` on google and only found this issue: https://github.com/segmentio/aws-okta/issues/116. I didn't see any documentation in the wiki or README about it, so I thought I'd add a short section in the README.