### PR TITLE
feat: sort roles listed in roles prompt

### DIFF
--- a/lib/provider.go
+++ b/lib/provider.go
@@ -227,7 +227,15 @@ func (p *Provider) getSamlSessionCreds() (sts.Credentials, error) {
 	} else {
 		profileARN, ok = p.profiles[source]["role_arn"]
 		if !ok {
-			return sts.Credentials{}, errors.New("Source profile must provide `role_arn`")
+			// profile does not have a role_arn. This is ok as the user will be promted
+			// to choose a role from all available roles
+			// Support profiles similar to below
+			//   [profile my-profile]
+			//   output = json
+			//   aws_saml_url = /home/some_saml_url
+			//   mfa_provider = FIDO
+			//   mfa_factor_type = u2f
+			log.Debugf("Profile '%s' does not have role_arn", source)
 		}
 	}
 


### PR DESCRIPTION
- Break it down by account ID to make it easier to find roles to select.
  Roles will be displayed similar to list below
   ```
    Account: 111111111111
      0 - arn:aws:iam::111111111111:role/my-role-1
      1 - arn:aws:iam::111111111111:role/my-role-2
      2 - arn:aws:iam::111111111111:role/my-role-3

    Account: 222222222222
      3 - arn:aws:iam::222222222222:role/other-role-1
      4 - arn:aws:iam::222222222222:role/other-role-2

    Select Role to Assume:
   ```

- Fix error when provided profile does not have a role_arn
  - User will be prompted to choose role from list of roles.