### PR TITLE
feat: Export expiration as AWS_OKTA_SESSION_EXPIRATION

### DIFF
--- a/cmd/env.go
+++ b/cmd/env.go
@@ -120,5 +120,7 @@ func envRun(cmd *cobra.Command, args []string) error {
 		fmt.Printf("export AWS_SECURITY_TOKEN=%s\n", shellescape.Quote(creds.SessionToken))
 	}
 
+	fmt.Printf("export AWS_OKTA_SESSION_EXPIRATION=%d\n", p.GetExpiration().Unix())
+
 	return nil
 }

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -229,6 +229,8 @@ func execRun(cmd *cobra.Command, args []string) error {
 		env.Set("AWS_SECURITY_TOKEN", creds.SessionToken)
 	}
 
+	env.Set("AWS_OKTA_SESSION_EXPIRATION", fmt.Sprintf("%d", p.GetExpiration().Unix()))
+
 	ecmd := exec.Command(command, commandArgs...)
 	ecmd.Stdin = os.Stdin
 	ecmd.Stdout = os.Stdout

--- a/lib/provider.go
+++ b/lib/provider.go
@@ -182,6 +182,10 @@ func (p *Provider) Retrieve() (credentials.Value, error) {
 	return value, nil
 }
 
+func (p *Provider) GetExpiration() time.Time {
+	return p.expires
+}
+
 func (p *Provider) getSamlURL() (string, error) {
 	oktaAwsSAMLUrl, profile, err := p.profiles.GetValue(p.profile, "aws_saml_url")
 	if err != nil {


### PR DESCRIPTION
This implements #190 as the `AWS_OKTA_SESSION_EXPIRATION` environment variable which is the expiration date as the number of seconds from the Unix epoch.