### PR TITLE
pipeline: add ubuntu 19.10 (eoan ermine); rm ubuntu cosmic

### DIFF
--- a/Makefile.release
+++ b/Makefile.release
@@ -22,8 +22,8 @@ PACKAGECLOUD_DEB_DISTROS := \
 	ubuntu/trusty \
 	ubuntu/xenial \
 	ubuntu/bionic \
-	ubuntu/cosmic \
-	ubuntu/disco
+	ubuntu/disco \
+	ubuntu/eoan
 
 PACKAGECLOUD_RPM_DISTROS := \
 	fedora/27 \


### PR DESCRIPTION
https://wiki.ubuntu.com/Releases says:

- eoan 2019-10-17 -- 2020-07
- cosmic 2018-10-18 -- 2019-07-18

Should address #233 when released. Not sure if this will require a PATCH release, or we can hack around it.