### PR TITLE
fix: Include the profileARN for the session cache key

### DIFF
--- a/internal/sessioncache/key_profilearn.go
+++ b/internal/sessioncache/key_profilearn.go
@@ -1,0 +1,33 @@
+package sessioncache
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+type KeyWithProfileARN struct {
+	ProfileName string
+	ProfileConf map[string]string
+	Duration    time.Duration
+	ProfileARN  string
+}
+
+// Key returns a key for the keyring item. For all purposes it behaves the same way as
+// OrigKey but also takes the ProfileARN into account when generating the key value.
+func (k KeyWithProfileARN) Key() string {
+	var source string
+	if source = k.ProfileConf["source_profile"]; source == "" {
+		source = k.ProfileName
+	}
+	hasher := md5.New()
+	hasher.Write([]byte(k.Duration.String()))
+	hasher.Write([]byte(k.ProfileARN))
+
+	enc := json.NewEncoder(hasher)
+	enc.Encode(k.ProfileConf)
+
+	return fmt.Sprintf("%s session (%x)", source, hex.EncodeToString(hasher.Sum(nil))[0:10])
+}

--- a/lib/provider.go
+++ b/lib/provider.go
@@ -121,10 +121,11 @@ func (p *Provider) Retrieve() (credentials.Value, error) {
 	if !ok {
 		return credentials.Value{}, fmt.Errorf("missing profile named %s", p.profile)
 	}
-	key := sessioncache.OrigKey{
+	key := sessioncache.KeyWithProfileARN{
 		ProfileName: source,
 		ProfileConf: profileConf,
 		Duration:    p.SessionDuration,
+		ProfileARN:  p.AssumeRoleArn,
 	}
 
 	var creds sts.Credentials


### PR DESCRIPTION
The profileARN can be overriden as part of the exec call.
This fixes a bug with the following commands:

- aws-okta exec profile --assume-role-arn role1 -- command
- aws-okta exec profile --assume-role-arn role2 -- command

The second command would be run using role1 since the session cache
thinks there's already a valid session. The cache lookup logic does not
take the assume role override into account when looking for a session.