### PR TITLE
Use regional endpoints for STS #225

### DIFF
--- a/lib/okta.go
+++ b/lib/okta.go
@@ -218,7 +218,8 @@ func (o *OktaClient) AuthenticateProfileWithRegion(profileARN string, duration t
 	if region != "" {
 		log.Debugf("Using region: %s\n", region)
 		conf := &aws.Config{
-			Region: aws.String(region),
+			Region:   aws.String(region),
+			Endpoint: aws.String(fmt.Sprintf("https://sts.%s.amazonaws.com", region)),
 		}
 		samlSess = session.Must(session.NewSession(conf))
 	} else {
@@ -251,9 +252,8 @@ func (o *OktaClient) AuthenticateProfileWithRegion(profileARN string, duration t
 	return *samlResp.Credentials, sessionCookie, nil
 }
 
-
 func (o *OktaClient) AuthenticateProfile(profileARN string, duration time.Duration) (sts.Credentials, string, error) {
-    return o.AuthenticateProfileWithRegion(profileARN, duration, "")
+	return o.AuthenticateProfileWithRegion(profileARN, duration, "")
 }
 
 func selectMFADeviceFromConfig(o *OktaClient) (*OktaUserAuthnFactor, error) {


### PR DESCRIPTION
After digging around a bit, I realised that you do not provide the `Endpoint` parameter to the `aws.Config{}` struct for sts. Because newer regions requires v2 tokens (see: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html and here: https://docs.aws.amazon.com/cli/latest/reference/iam/set-security-token-service-preferences.html) enabled on the global endpoint (and this is not enabled per default), using regional endpoints is safer as they're guaranteed to work with the region you're trying to access.

This fixes #225 