### PR TITLE
fix: Produce prompts on stderr

### DIFF
--- a/lib/prompt.go
+++ b/lib/prompt.go
@@ -11,7 +11,7 @@ import (
 )
 
 func Prompt(prompt string, sensitive bool) (string, error) {
-	return PromptWithOutput(prompt, sensitive, os.Stdout)
+	return PromptWithOutput(prompt, sensitive, os.Stderr)
 }
 
 func PromptWithOutput(prompt string, sensitive bool, output *os.File) (string, error) {

--- a/lib/utils.go
+++ b/lib/utils.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -107,13 +108,13 @@ func GetRole(roleList saml.AssumableRoles, profileARN string) (saml.AssumableRol
 	for i, arole := range roleList {
 		currentAccountID, roleName = accountIDAndRoleFromRoleARN(arole.Role)
 		if currentAccountID != previousAccountID {
-			fmt.Printf("\nAccount: %s\n", currentAccountID)
+			fmt.Fprintf(os.Stderr, "\nAccount: %s\n", currentAccountID)
 		}
 		previousAccountID = currentAccountID
 
-		fmt.Printf("%4d - %s\n", i, roleName)
+		fmt.Fprintf(os.Stderr, "%4d - %s\n", i, roleName)
 	}
-	fmt.Println("")
+	fmt.Fprintln(os.Stderr, "")
 
 	i, err := Prompt("Select Role to Assume", false)
 	if err != nil {


### PR DESCRIPTION
This enables scriptability of aws-okta, this appears to already be the case for some of the prompting things.

### before

(it hangs forever at the end of the output, I found it is prompting for the Role here)

```console
$ ./aws-okta exec "$ROLE" -- echo hi > log
INFO[0001] Requesting MFA. Please complete two-factor authentication with your second device 
INFO[0001] Select a MFA from the following list         
INFO[0001] 0: DUO (web)                                 
INFO[0001] 1: GOOGLE (token:software:totp)              
0
INFO[0004] Sending Push Notification...                 
INFO[0005] Device: phone1           
```

### after

(output is doctored a bit to obfuscate our account ids / etc.)

```console
$ ./aws-okta exec "$ROLE" -- echo hi > log
INFO[0001] Requesting MFA. Please complete two-factor authentication with your second device 
INFO[0001] Select a MFA from the following list         
INFO[0001] 0: DUO (web)                                 
INFO[0001] 1: GOOGLE (token:software:totp)              
Select MFA method: 0

INFO[0003] Sending Push Notification...                 
INFO[0004] Device: phone1                               

Account: 1234
   0 - bless-user

<< snip >>

Select Role to Assume: 0
$
```