### PR TITLE
feat: allow users to configure log level

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -168,22 +168,9 @@ func getLogLevel(logLevel string, debug bool) log.Level {
 		return log.DebugLevel
 	}
 
-	switch logLevel {
-	case "trace":
-		return log.TraceLevel
-	case "debug":
+	level, err := log.ParseLevel(logLevel)
+	if err != nil {
 		return log.DebugLevel
-	case "info":
-		return log.InfoLevel
-	case "warn":
-		return log.WarnLevel
-	case "error":
-		return log.ErrorLevel
-	case "fatal":
-		return log.FatalLevel
-	case "panic":
-		return log.PanicLevel
-	default:
-		return log.InfoLevel
 	}
+	return level
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -79,7 +79,11 @@ func prerunE(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	log.SetLevel(getLogLevel(logLevel, debug))
+	level, err := getLogLevel(logLevel, debug)
+	if err != nil {
+		return xerrors.Errorf("couldn't parse log-level: %s: %w", logLevel, err)
+	}
+	log.SetLevel(level)
 
 	if !cmd.Flags().Lookup("session-cache-single-item").Changed {
 		val, ok := os.LookupEnv(envSessionCacheSingleItem)
@@ -163,14 +167,10 @@ func updateMfaConfig(cmd *cobra.Command, profiles lib.Profiles, profile string, 
 	}
 }
 
-func getLogLevel(logLevel string, debug bool) log.Level {
+func getLogLevel(logLevel string, debug bool) (log.Level, error) {
 	if debug {
-		return log.DebugLevel
+		return log.DebugLevel, nil
 	}
 
-	level, err := log.ParseLevel(logLevel)
-	if err != nil {
-		return log.DebugLevel
-	}
-	return level
+	return log.ParseLevel(logLevel)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -127,7 +127,7 @@ func init() {
 	RootCmd.PersistentFlags().StringVarP(&mfaConfig.FactorType, "mfa-factor-type", "", "", "MFA Factor Type to use (eg push, token:software:totp)")
 	RootCmd.PersistentFlags().StringVarP(&mfaConfig.DuoDevice, "mfa-duo-device", "", "phone1", "Device to use phone1, phone2, u2f or token")
 	RootCmd.PersistentFlags().StringVarP(&backend, "backend", "b", "", fmt.Sprintf("Secret backend to use %s", backendsAvailable))
-	RootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "", "Configure the desired log level")
+	RootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "info", "Configure the desired log level")
 	RootCmd.PersistentFlags().BoolVarP(&debug, "debug", "d", false, "Enable debug logging. Overrides log-level.")
 	RootCmd.PersistentFlags().BoolVarP(&flagSessionCacheSingleItem, "session-cache-single-item", "", false, fmt.Sprintf("(alpha) Enable single-item session cache; aka %s", envSessionCacheSingleItem))
 }


### PR DESCRIPTION
AWS SDKs capture the output of `cred-process` and expect it to be json formatted. Unfortunately, output such as 
```
INFO[0001] Requesting MFA. Please complete two-factor authentication with your second device 
INFO[0001] Sending Push Notification...
```
is incompatible with this scheme.

This change lets users set their desired log level allowing users of cred-process to ensure only json is outputted to stdout. (see https://github.com/segmentio/aws-okta/issues/253)