### PR TITLE
feat: Support "session_ttl" config param in every command (#251)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Usage:
   aws-okta exec <profile> -- <command>
 
 Flags:
-  -a, --assume-role-ttl duration   Expiration time for assumed role (default 15m0s)
+  -a, --assume-role-ttl duration   Expiration time for assumed role (default 1h0m0s)
   -h, --help                       help for exec
   -t, --session-ttl duration       Expiration time for okta role session (default 1h0m0s)
 
@@ -147,9 +147,14 @@ role_arn = arn:aws:iam::<account-id>:role/<okta-role-name>
 okta_account_name = account-b
 ```
 
-#### Configuring Okta session and AWS assume role TTLs
+#### Configuring Okta assume role and AWS assume role TTLs
 
-The default TTLs for both Okta sessions and AWS assumed roles is 1 hour.  This means that aws-okta will re-authenticate to Okta and AWS credentials will expire every hour.  In addition to specifying the Okta session and AWS assume role TTLs with the command-line flags, they can be set using the `AWS_SESSION_TTL` and `AWS_ASSUME_ROLE_TTL` environment variables respectively.
+The default TTLs for both the initial SAML assumed role and secondary AWS assumed roles are 1 hour.  This means that AWS credentials will expire every hour.
+
+* *session-ttl*: Duration of initial role assumed by Okta
+* *assume-role-ttl*: Duration of second role assumed
+
+In addition to specifying session and AWS assume role TTLs with command-line flags, they can be set using environment variables.
 
 ```bash
 export AWS_SESSION_TTL=1h
@@ -159,10 +164,15 @@ export AWS_ASSUME_ROLE_TTL=1h
 The AWS assume role TTL can also be set per-profile in the aws config:
 
 ```ini
-# example with a role that's configured with a max session duration of 12 hours
+# Example with an initial and secondary role that are configured with a max session duration of 12 hours
 [profile ttldemo]
 aws_saml_url = home/amazon_aws/cuZGoka9dAIFcyG0UllG/214
 role_arn = arn:aws:iam::<account-id>:role/<okta-role-name>
+session_ttl = 12h
+
+[profile ttldemo-role]
+source_profile = ttldemo
+role_arn = arn:aws:iam::<account-id>:role/<secondary-role-name>
 assume_role_ttl = 12h
 ```
 

--- a/cmd/cred-process.go
+++ b/cmd/cred-process.go
@@ -62,10 +62,16 @@ func credProcessRun(cmd *cobra.Command, args []string) error {
 
 	updateMfaConfig(cmd, profiles, profile, &mfaConfig)
 
-	// check for an assume_role_ttl in the profile if we don't have a more explicit one
+	// check profile for both session durations if not explicitly set
 	if !cmd.Flags().Lookup("assume-role-ttl").Changed {
-		if err := updateDurationFromConfigProfile(profiles, profile, &assumeRoleTTL); err != nil {
-			fmt.Fprintln(os.Stderr, "warning: could not parse duration from profile config")
+		if err := updateDurationFromConfigProfile(profiles, profile, "assume_role_ttl", &assumeRoleTTL); err != nil {
+			fmt.Fprintln(os.Stderr, "warning: could not parse assume_role_ttl from profile config")
+		}
+	}
+
+	if !cmd.Flags().Lookup("session-ttl").Changed {
+		if err := updateDurationFromConfigProfile(profiles, profile, "session_ttl", &sessionTTL); err != nil {
+			fmt.Fprintln(os.Stderr, "warning: could not parse session_ttl from profile config")
 		}
 	}
 

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -50,10 +50,16 @@ func envRun(cmd *cobra.Command, args []string) error {
 
 	updateMfaConfig(cmd, profiles, profile, &mfaConfig)
 
-	// check for an assume_role_ttl in the profile if we don't have a more explicit one
+	// check profile for both session durations if not explicitly set
 	if !cmd.Flags().Lookup("assume-role-ttl").Changed {
-		if err := updateDurationFromConfigProfile(profiles, profile, &assumeRoleTTL); err != nil {
-			fmt.Fprintln(os.Stderr, "warning: could not parse duration from profile config")
+		if err := updateDurationFromConfigProfile(profiles, profile, "assume_role_ttl", &assumeRoleTTL); err != nil {
+			fmt.Fprintln(os.Stderr, "warning: could not parse assume_role_ttl from profile config")
+		}
+	}
+
+	if !cmd.Flags().Lookup("session-ttl").Changed {
+		if err := updateDurationFromConfigProfile(profiles, profile, "session_ttl", &sessionTTL); err != nil {
+			fmt.Fprintln(os.Stderr, "warning: could not parse session_ttl from profile config")
 		}
 	}
 

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -83,8 +83,8 @@ func loadStringFlagFromEnv(cmd *cobra.Command, flagName string, envVar string, v
 	return nil
 }
 
-func updateDurationFromConfigProfile(profiles lib.Profiles, profile string, val *time.Duration) error {
-	fromProfile, _, err := profiles.GetValue(profile, "assume_role_ttl")
+func updateDurationFromConfigProfile(profiles lib.Profiles, profile string, key string, val *time.Duration) error {
+	fromProfile, _, err := profiles.GetValue(profile, key)
 	if err != nil {
 		return nil
 	}
@@ -150,10 +150,16 @@ func execRun(cmd *cobra.Command, args []string) error {
 
 	updateMfaConfig(cmd, profiles, profile, &mfaConfig)
 
-	// check for an assume_role_ttl in the profile if we don't have a more explicit one
+	// check profile for both session durations if not explicitly set
 	if !cmd.Flags().Lookup("assume-role-ttl").Changed {
-		if err := updateDurationFromConfigProfile(profiles, profile, &assumeRoleTTL); err != nil {
-			fmt.Fprintln(os.Stderr, "warning: could not parse duration from profile config")
+		if err := updateDurationFromConfigProfile(profiles, profile, "assume_role_ttl", &assumeRoleTTL); err != nil {
+			fmt.Fprintln(os.Stderr, "warning: could not parse assume_role_ttl from profile config")
+		}
+	}
+
+	if !cmd.Flags().Lookup("session-ttl").Changed {
+		if err := updateDurationFromConfigProfile(profiles, profile, "session_ttl", &sessionTTL); err != nil {
+			fmt.Fprintln(os.Stderr, "warning: could not parse session_ttl from profile config")
 		}
 	}
 

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -72,10 +72,16 @@ func loginRun(cmd *cobra.Command, args []string) error {
 
 	updateMfaConfig(cmd, profiles, profile, &mfaConfig)
 
-	// check for an assume_role_ttl in the profile if we don't have a more explicit one
+	// check profile for both session durations if not explicitly set
 	if !cmd.Flags().Lookup("assume-role-ttl").Changed {
-		if err := updateDurationFromConfigProfile(profiles, profile, &assumeRoleTTL); err != nil {
-			fmt.Fprintln(os.Stderr, "warning: could not parse duration from profile config")
+		if err := updateDurationFromConfigProfile(profiles, profile, "assume_role_ttl", &assumeRoleTTL); err != nil {
+			fmt.Fprintln(os.Stderr, "warning: could not parse assume_role_ttl from profile config")
+		}
+	}
+
+	if !cmd.Flags().Lookup("session-ttl").Changed {
+		if err := updateDurationFromConfigProfile(profiles, profile, "session_ttl", &sessionTTL); err != nil {
+			fmt.Fprintln(os.Stderr, "warning: could not parse session_ttl from profile config")
 		}
 	}
 

--- a/cmd/write-to-credentials.go
+++ b/cmd/write-to-credentials.go
@@ -56,10 +56,16 @@ func writeToCredentialsRun(cmd *cobra.Command, args []string) error {
 
 	updateMfaConfig(cmd, profiles, profile, &mfaConfig)
 
-	// check for an assume_role_ttl in the profile if we don't have a more explicit one
+	// check profile for both session durations if not explicitly set
 	if !cmd.Flags().Lookup("assume-role-ttl").Changed {
-		if err := updateDurationFromConfigProfile(profiles, profile, &assumeRoleTTL); err != nil {
-			fmt.Fprintln(os.Stderr, "warning: could not parse duration from profile config")
+		if err := updateDurationFromConfigProfile(profiles, profile, "assume_role_ttl", &assumeRoleTTL); err != nil {
+			fmt.Fprintln(os.Stderr, "warning: could not parse assume_role_ttl from profile config")
+		}
+	}
+
+	if !cmd.Flags().Lookup("session-ttl").Changed {
+		if err := updateDurationFromConfigProfile(profiles, profile, "session_ttl", &sessionTTL); err != nil {
+			fmt.Fprintln(os.Stderr, "warning: could not parse session_ttl from profile config")
 		}
 	}
 


### PR DESCRIPTION
If "session_ttl" exists in config profile, use it as if --session-ttl was provided on the CLI.

This creates config parity between "session-ttl" and "assume-role-ttl".

I believe only one term is necessary, but we can address that in a later issue.