### PR TITLE
feat: Persist device token cookie in keystore to prevent repeated MFA prompt

### DIFF
--- a/lib/okta.go
+++ b/lib/okta.go
@@ -495,7 +495,7 @@ func (o *OktaClient) challengeMFA() (err error) {
 
 	payload, err = o.preChallenge(oktaFactorId, oktaFactorType)
 
-	err = o.Get("POST", "api/v1/authn/factors/"+oktaFactorId+"/verify",
+	err = o.Get("POST", "api/v1/authn/factors/"+oktaFactorId+"/verify?rememberDevice=true",
 		payload, &o.UserAuth, "json",
 	)
 	if err != nil {

--- a/lib/okta.go
+++ b/lib/okta.go
@@ -74,9 +74,16 @@ type OktaCreds struct {
 	Domain       string
 }
 
+type OktaCookies struct {
+	Session string
+	DeviceToken string
+}
+
 func (c *OktaCreds) Validate(mfaConfig MFAConfig) error {
 	// OktaClient assumes we're doing some AWS SAML calls, but Validate doesn't
-	o, err := NewOktaClient(*c, "", "", mfaConfig)
+	var cookies OktaCookies
+
+	o, err := NewOktaClient2(*c, "", cookies, mfaConfig)
 	if err != nil {
 		return err
 	}
@@ -101,6 +108,13 @@ func GetOktaDomain(region string) (string, error) {
 }
 
 func NewOktaClient(creds OktaCreds, oktaAwsSAMLUrl string, sessionCookie string, mfaConfig MFAConfig) (*OktaClient, error) {
+	var cookies OktaCookies
+	cookies.Session = sessionCookie
+
+	return NewOktaClient2(creds, oktaAwsSAMLUrl, cookies, mfaConfig)
+}
+
+func NewOktaClient2(creds OktaCreds, oktaAwsSAMLUrl string, cookies OktaCookies, mfaConfig MFAConfig) (*OktaClient, error) {
 	var domain string
 
 	// maintain compatibility for deprecated creds.Organization
@@ -125,11 +139,19 @@ func NewOktaClient(creds OktaCreds, oktaAwsSAMLUrl string, sessionCookie string,
 		return nil, err
 	}
 
-	if sessionCookie != "" {
+	if cookies.Session != "" {
 		jar.SetCookies(base, []*http.Cookie{
 			{
 				Name:  "sid",
-				Value: sessionCookie,
+				Value: cookies.Session,
+			},
+		})
+	}
+	if cookies.DeviceToken != "" {
+		jar.SetCookies(base, []*http.Cookie{
+			{
+				Name:  "DT",
+				Value: cookies.DeviceToken,
 			},
 		})
 	}
@@ -187,30 +209,41 @@ func (o *OktaClient) AuthenticateUser() error {
 	return nil
 }
 
+func (o *OktaClient) AuthenticateProfile(profileARN string, duration time.Duration) (sts.Credentials, string, error) {
+	return o.AuthenticateProfileWithRegion(profileARN, duration, "")
+}
+
 func (o *OktaClient) AuthenticateProfileWithRegion(profileARN string, duration time.Duration, region string) (sts.Credentials, string, error) {
+	creds, cookies, err := o.AuthenticateProfile3(profileARN, duration, region)
+
+	return creds, cookies.Session, err
+}
+
+func (o *OktaClient) AuthenticateProfile3(profileARN string, duration time.Duration, region string) (sts.Credentials, OktaCookies, error) {
 
 	// Attempt to reuse session cookie
 	var assertion SAMLAssertion
+	var oc OktaCookies
 
 	err := o.Get("GET", o.OktaAwsSAMLUrl, nil, &assertion, "saml")
 	if err != nil {
 		log.Debug("Failed to reuse session token, starting flow from start")
 
 		if err := o.AuthenticateUser(); err != nil {
-			return sts.Credentials{}, "", err
+			return sts.Credentials{}, oc, err
 		}
 
 		// Step 3 : Get SAML Assertion and retrieve IAM Roles
 		log.Debug("Step: 3")
 		if err = o.Get("GET", o.OktaAwsSAMLUrl+"?onetimetoken="+o.UserAuth.SessionToken,
 			nil, &assertion, "saml"); err != nil {
-			return sts.Credentials{}, "", err
+			return sts.Credentials{}, oc, err
 		}
 	}
 
 	principal, role, err := GetRoleFromSAML(assertion.Resp, profileARN)
 	if err != nil {
-		return sts.Credentials{}, "", err
+		return sts.Credentials{}, oc, err
 	}
 
 	// Step 4 : Assume Role with SAML
@@ -239,22 +272,20 @@ func (o *OktaClient) AuthenticateProfileWithRegion(profileARN string, duration t
 	if err != nil {
 		log.WithField("role", role).Errorf(
 			"error assuming role with SAML: %s", err.Error())
-		return sts.Credentials{}, "", err
+		return sts.Credentials{}, oc, err
 	}
 
-	var sessionCookie string
 	cookies := o.CookieJar.Cookies(o.BaseURL)
 	for _, cookie := range cookies {
 		if cookie.Name == "sid" {
-			sessionCookie = cookie.Value
+			oc.Session = cookie.Value
+		}
+		if cookie.Name == "DT" {
+			oc.DeviceToken = cookie.Value
 		}
 	}
 
-	return *samlResp.Credentials, sessionCookie, nil
-}
-
-func (o *OktaClient) AuthenticateProfile(profileARN string, duration time.Duration) (sts.Credentials, string, error) {
-	return o.AuthenticateProfileWithRegion(profileARN, duration, "")
+	return *samlResp.Credentials, oc, nil
 }
 
 func selectMFADeviceFromConfig(o *OktaClient) (*OktaUserAuthnFactor, error) {
@@ -612,31 +643,46 @@ func (p *OktaProvider) Retrieve() (sts.Credentials, string, error) {
 		return sts.Credentials{}, "", errors.New("Failed to get okta credentials from your keyring.  Please make sure you have added okta credentials with `aws-okta add`")
 	}
 
-	// Check for stored session cookie
-	var sessionCookie string
+	// Check for stored session and device token cookies
+	var cookies OktaCookies
 	cookieItem, err := p.Keyring.Get(p.OktaSessionCookieKey)
 	if err == nil {
-		sessionCookie = string(cookieItem.Data)
+		cookies.Session = string(cookieItem.Data)
+	}
+	cookieItem2, err := p.Keyring.Get("okta-device-token-cookie")
+	if err == nil {
+		cookies.DeviceToken = string(cookieItem2.Data)
 	}
 
-	oktaClient, err := NewOktaClient(oktaCreds, p.OktaAwsSAMLUrl, sessionCookie, p.MFAConfig)
+	oktaClient, err := NewOktaClient2(oktaCreds, p.OktaAwsSAMLUrl, cookies, p.MFAConfig)
 	if err != nil {
 		return sts.Credentials{}, "", err
 	}
 
-	creds, newSessionCookie, err := oktaClient.AuthenticateProfileWithRegion(p.ProfileARN, p.SessionDuration, p.AwsRegion)
+	creds, newCookies, err := oktaClient.AuthenticateProfile3(p.ProfileARN, p.SessionDuration, p.AwsRegion)
 	if err != nil {
 		return sts.Credentials{}, "", err
 	}
+
+	log.Debug("pOktaSessionCookieKey: ", p.OktaSessionCookieKey)
 
 	newCookieItem := keyring.Item{
 		Key:                         p.OktaSessionCookieKey,
-		Data:                        []byte(newSessionCookie),
+		Data:                        []byte(newCookies.Session),
 		Label:                       "okta session cookie",
 		KeychainNotTrustApplication: false,
 	}
 
 	p.Keyring.Set(newCookieItem)
+
+	newCookieItem2 := keyring.Item{
+		Key:                         "okta-device-token-cookie",
+		Data:                        []byte(newCookies.DeviceToken),
+		Label:                       "okta device token",
+		KeychainNotTrustApplication: false,
+	}
+
+	p.Keyring.Set(newCookieItem2)
 
 	return creds, oktaCreds.Username, err
 }


### PR DESCRIPTION
# Overview
 
Based on @Chippiewill PR #213
    
When using MFA, Okta expects the device token cookie `DT` in addition to
the session ID cookie `sid`. If MFA is required in the Okta app and this
cookie is not sent the session fails. This causes `aws-okta` to go
through the entire authentication flow again, eliminating any benefits
of session caching.
    
This change persists the device token the same way as the session ID.
    
I've kept the existing API identical, adding new function calls that
take an OktaCookies struct.

# Testing

Manual testing with Push notification and Okta AWS application setup to require MFA "Per Session" and "Once per Day".

With both patches in place, the Okta session is successfully reused, without MFA prompt, to create new AWS STS tokens when the previous STS token is expired.