### PR TITLE
Fix error checking for exit status

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -256,12 +256,12 @@ func execRun(cmd *cobra.Command, args []string) error {
 
 	var waitStatus syscall.WaitStatus
 	if err := ecmd.Run(); err != nil {
-		if err != nil {
-			return err
-		}
 		if exitError, ok := err.(*exec.ExitError); ok {
 			waitStatus = exitError.Sys().(syscall.WaitStatus)
 			os.Exit(waitStatus.ExitStatus())
+		}
+		if err != nil {
+			return err
 		}
 	}
 	return nil


### PR DESCRIPTION
The `ExitError` code was not reachable due to a nil check. This change fixes that logic