### PR TITLE
[bugfix] Add mfa_duo_device option to aws profile

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -135,7 +135,12 @@ func updateMfaConfig(cmd *cobra.Command, profiles lib.Profiles, profile string, 
 		if ok {
 			config.DuoDevice = mfaDeviceFromEnv
 		} else {
-			config.DuoDevice = DefaultMFADuoDevice
+			duoDevice, _, err := profiles.GetValue(profile, "mfa_duo_device")
+			if err == nil {
+				config.DuoDevice = duoDevice
+			} else {
+				config.DuoDevice = DefaultMFADuoDevice
+			}
 		}
 	}
 


### PR DESCRIPTION
Currently the only way to set a duo device is as a command line argument or an
environment variable. This change adds support for setting the duo device in
your aws config

```
[okta]
aws_saml_url = ...
mfa_provider = DUO
mfa_factor_type = web
mfa_duo_device = token
assumed_role_ttl = 12h
```