### PR TITLE
Fix session ID handling

### DIFF
--- a/lib/duo.go
+++ b/lib/duo.go
@@ -28,10 +28,12 @@ type DuoClient struct {
 	Callback   string
 	Device     string
 	StateToken string
+	FactorID   string
 }
 
 type StatusResp struct {
 	Response struct {
+		SessionID      string `json:"sid"`
 		U2FSignRequest []struct {
 			Version   string `json:"version"`
 			Challenge string `json:"challenge"`
@@ -57,12 +59,13 @@ type PromptResp struct {
 	Stat string `json:"stat"`
 }
 
-func NewDuoClient(host, signature, callback string) *DuoClient {
+func NewDuoClient(host, signature, callback, factorID string) *DuoClient {
 	return &DuoClient{
 		Host:      host,
 		Signature: signature,
 		Device:    "phone1",
 		Callback:  callback,
+		FactorID:  factorID,
 	}
 }
 
@@ -460,7 +463,7 @@ func (d *DuoClient) DoStatus(txid, sid string) (auth string, status StatusResp, 
 
 	if status.Response.Result == "SUCCESS" {
 		if status.Response.ResultURL != "" {
-			auth, err = d.DoRedirect(status.Response.ResultURL, sid)
+			auth, err = d.DoRedirect(status.Response.ResultURL, status.Response.SessionID)
 		} else {
 			auth = status.Response.Cookie
 		}
@@ -514,7 +517,7 @@ func (d *DuoClient) DoCallback(auth string) (err error) {
 
 	client := &http.Client{}
 
-	callbackData := "stateToken=" + d.StateToken + "&sig_response=" + sigResp
+	callbackData := "id=" + d.FactorID + "&stateToken=" + d.StateToken + "&sig_response=" + sigResp
 	req, err = http.NewRequest("POST", d.Callback, bytes.NewReader([]byte(callbackData)))
 	if err != nil {
 		return

--- a/lib/okta.go
+++ b/lib/okta.go
@@ -232,7 +232,7 @@ func (o *OktaClient) AuthenticateProfile3(profileARN string, duration time.Durat
 		// Clear DT cookie before starting AuthN flow again. Bug #279.
 		o.CookieJar.SetCookies(o.BaseURL, []*http.Cookie{
 			{
-				Name:  "DT",
+				Name:   "DT",
 				MaxAge: -1,
 			},
 		})
@@ -412,6 +412,7 @@ func (o *OktaClient) postChallenge(payload []byte, oktaFactorProvider string, ok
 					Callback:   f.Embedded.Verification.Links.Complete.Href,
 					Device:     o.MFAConfig.DuoDevice,
 					StateToken: o.UserAuth.StateToken,
+					FactorID:   f.Id,
 				}
 
 				log.Debugf("Host:%s\nSignature:%s\nStateToken:%s\n",


### PR DESCRIPTION
A new session ID is being returned from the last frame status call before issuing another redirect to get the last signature. This session ID is needed for the redirect to work. We were passing a session ID but it was stale.

Best guess as to root cause is that something must have changed in the /frame/status endpoint to return this new session ID. All I know is that this restores functionality.