### PR TITLE
Fix cred process expiration

### DIFF
--- a/cmd/cred-process.go
+++ b/cmd/cred-process.go
@@ -122,8 +122,7 @@ func credProcessRun(cmd *cobra.Command, args []string) error {
 		AccessKeyID:     creds.AccessKeyID,
 		SecretAccessKey: creds.SecretAccessKey,
 		SessionToken:    creds.SessionToken,
-		// reuse the provided session duration
-		Expiration: time.Now().Add(p.SessionDuration).Format(time.RFC3339),
+		Expiration:      p.GetExpiration().Format(time.RFC3339),
 	}
 
 	var output []byte


### PR DESCRIPTION
The Expiration field conveyed the wrong value. It's changed to be the
same value that's used in aws-okta exec.